### PR TITLE
Parse form encoded response body

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -74,7 +74,7 @@
     }
 
     this.formData = function() {
-      throw new Error('Not implemented yet')
+      return Promise.resolve(decode(this.body))
     }
 
     this.json = function() {
@@ -113,6 +113,19 @@
       var value = (params[name] === null) ? '' : params[name]
       return encodeURIComponent(name) + '=' + encodeURIComponent(value)
     }).join('&').replace(/%20/g, '+')
+  }
+
+  function decode(body) {
+    var form = new FormData()
+    body.trim().split('&').forEach(function(bytes) {
+      if (bytes) {
+        var split = bytes.split('=')
+        var name = split.shift().replace(/\+/g, ' ')
+        var value = split.join('=').replace(/\+/g, ' ')
+        form.append(decodeURIComponent(name), decodeURIComponent(value))
+      }
+    })
+    return form
   }
 
   function isObject(value) {

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,9 @@ MockXHR.responses = {
   '/error': function(xhr) {
     xhr.error()
   },
+  '/form': function(xhr) {
+    xhr.respond(200, 'number=1&space=one+two&empty=&encoded=a%2Bb&')
+  },
   '/json': function(xhr) {
     xhr.respond(200, JSON.stringify({name: 'Hubot', login: 'hubot'}))
   },
@@ -76,6 +79,15 @@ asyncTest('resolves text promise', 1, function() {
     return response.text()
   }).then(function(text) {
     equal(text, 'hi')
+    start()
+  })
+})
+
+asyncTest('parses form encoded response', 1, function() {
+  fetch('/form').then(function(response) {
+    return response.formData()
+  }).then(function(form) {
+    ok(form instanceof FormData, 'Parsed a FormData object')
     start()
   })
 })


### PR DESCRIPTION
Implements the `Body#formData` promise, parsing a form encoded response according to https://url.spec.whatwg.org/#concept-urlencoded-parser.

The `FormData` object currently only has an `append` method, so there isn't a good way to inspect and test the result. Its API is more fully specified in https://xhr.spec.whatwg.org/#formdata, though, so maybe in the future.
