### PR TITLE
use shorthand npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ bower install es6-promise
 This can be also be installed with `npm`.
 
 ```
-npm install --save "https://github.com/github/fetch.git#v0.2.1"
+npm install github/fetch --save
 ```
 
 ## Usage


### PR DESCRIPTION
The npm client supports `user/repo` and `org/repo` installation shorthand.
