### PR TITLE
Added Common JS, Require JS and Global support

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  if (window.fetch) {
+  if ('undefined' != typeof window && window.fetch) {
     return
   }
 
@@ -211,8 +211,18 @@
   }
 
   Body.call(Response.prototype)
-
-  window.fetch = function (url, options) {
+  
+  var e = function (url, options) {
     return new Request(url, options).fetch()
+  };
+  
+  if ("object" == typeof exports && "undefined" != typeof module) {
+    module.exports = e;
+  } else if("function" == typeof define && define.amd) {
+    define([], function () { return e; });
+  } else {
+    var f;
+    "undefined" != typeof window ? f = window : "undefined" != typeof global ? f = global : "undefined" != typeof self && (f=self),f.fetch = e;
   }
+  
 })();


### PR DESCRIPTION
Hi,

Currently it is not possible to use fetch in a workflow. You have to load it separately and that is kind of a pain. With these changes fetch still loads Globally, but if using browserify, webpack etc. it loads as a module. In requirejs you do not have to shim, you load it as any other library. It can also load in Node, though Promises is not natively available until next (0.11.13) version.

Of course "fetch" is a polyfill for the global fetch method, but since it is an NPM module, my opinion is that it should support using it like the others. Logic is from browserify "standalone". 

Thanks for building it :-)
