### PR TITLE
Auto-detect available port when running headless tests

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
+set -e
 
-function stop() {
-  kill -9 $(<test/server.pid)
-  rm test/server.pid
-}
-trap stop EXIT
+port=3900
 
-node ./test/server.js & echo "$!" > test/server.pid
+# Find next available port
+while lsof -i :$((++port)) >/dev/null; do true; done
 
-node ./node_modules/.bin/node-qunit-phantomjs http://localhost:3000/test/test.html
+# Spin a test server in the background
+node ./test/server.js $port &>/dev/null &
+server_pid=$!
+trap "kill $server_pid" INT EXIT
+
+node ./node_modules/.bin/node-qunit-phantomjs "http://localhost:$port/test/test.html"

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var port = Number(process.argv[2] || 3000)
+
 var fs = require('fs')
 var http = require('http');
 var url = require('url');
@@ -66,4 +68,4 @@ http.createServer(function(req, res) {
       }
     });
   }
-}).listen(3000);
+}).listen(port);


### PR DESCRIPTION
By default the test server tried to run on port 3000, which would fail with a misleading message if something else happened to occupy that port on the system (such as a Rails app).

Now start incrementing the port number from 3900 and stop when the port is found to be available.
