### PR TITLE
Document how to use in Browserify…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ bower install fetch
 You'll also need a Promise polyfill for older browsers.
 
 ```sh
-$ bower install native-promise-only
+$ bower install es6-promise
 ```
 
 This can be also be installed with `npm`.
@@ -27,7 +27,7 @@ $ npm install github/fetch --save
 ### Using with npm and Browserify
 
 ```js
-require('native-promise-only');
+require('es6-promise').polyfill();
 require('fetch');
 ```
 


### PR DESCRIPTION
… as per #21. This is just a quick first pass, I'm almost certainly using too many words here.
- I've proposed changing the suggest ES6 Promise implementation to [`native-promise-only`](https://github.com/getify/native-promise-only) as I believe its API is more similar to the CommonJS API fetch has*.  Would you like me to change that back?
- Would you like me to squash my commits?
- Is ‘fuzzy versions’ clear enough or should I change this to ‘version ranges’?

\*  The equivalent for `es6-promise` is:

``` js
require('es6-promise').polyfill(); // require('native-promise-only');
```

It would be nice if we can do #9 because it would simplify some of this explanation (around fuzzy versions/version ranges) greatly.
