### PR TITLE
Reject promise with TypeError for network failures.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -162,7 +162,7 @@
       xhr.onload = function() {
         var status = (xhr.status === 1223) ? 204 : xhr.status
         if (status < 100 || status > 599) {
-          reject()
+          reject(new TypeError('Network request failed'))
           return
         }
         var options = {
@@ -174,7 +174,7 @@
       }
 
       xhr.onerror = function() {
-        reject()
+        reject(new TypeError('Network request failed'))
       }
 
       xhr.open(self.method, self.url)

--- a/test/test.js
+++ b/test/test.js
@@ -54,8 +54,8 @@ asyncTest('rejects promise for network error', 1, function() {
   fetch('/error').then(function(response) {
     ok(false, 'HTTP status ' + response.status + ' was treated as success')
     start()
-  }).catch(function() {
-    ok(true)
+  }).catch(function(error) {
+    ok(error instanceof TypeError, 'Rejected with Error')
     start()
   })
 })


### PR DESCRIPTION
[Section 5.6 Fetch method](https://fetch.spec.whatwg.org/#fetch-method) of the specification says:

> To process response for _response_, run these substeps:
> 1. If _response_'s type is _error_, reject _p_ with a `TypeError`.
> 2. Otherwise, resolve _p_ with new `Response` object associated with _response_.

This branch brings the implementation in line with step one of the response handling. Previously, we rejected the Promise without a reason object when the network request failed to produce a response. Now we reject with a `TypeError` for any registered `catch` handlers to process.

@annevk Is this a correct understanding of this section of the spec?
