### PR TITLE
Expose Headers, Request and Response to window

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -203,6 +203,10 @@
 
   Body.call(Response.prototype)
 
+  window.Headers = Headers;
+  window.Request = Request;
+  window.Response = Response;
+
   window.fetch = function (url, options) {
     return new Request(url, options).fetch()
   }


### PR DESCRIPTION
These three constructor should expose to global (window and worker).
Especially Headers.
Because headers in fetch option accepts native object and Header object.