### PR TITLE
Put back window object as 'this' is unoverrideable in node

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -206,4 +206,4 @@
   global.fetch = function (url, options) {
     return new Request(url, options).fetch()
   }
-})(this);
+})(typeof window === 'undefined' ? this : window);


### PR DESCRIPTION
Because `this` cannot be overridden inside node context (node is silly an 'this' _isn't_ the global object, as per frontend JS) [this PR](https://github.com/github/fetch/pull/48) breaks https://github.com/matthew-andrews/isomorphic-fetch (and this make fetch unusable in Node in general by making fetch a private method).

You know I really don't like polluting front end modules with server side stuff but otherwise PR 48 renders this library unusable in Node which has to be worse than a little pollution… :disappointed: 

This line will detect the Node specific 'global' object and add itself to that if it detects it.

I've prepared two PRs with two possible solutions, this one is slightly better from a frontend point of view because it sort of at least does _something_ in the front end, even if that thing is a bit pointless… the other one is a bit nicer from a node point of view and allows the isomorphic fetch library to do slightly less.
