### PR TITLE
Switch to Mocha

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
   "version": "0.4.0",
   "main": "fetch.js",
   "devDependencies": {
-    "es6-promise": "1.0.0",
-    "qunit": "1.14.0"
+    "es6-promise": "1.0.0"
   },
   "ignore": [
     ".*",

--- a/fetch.js
+++ b/fetch.js
@@ -92,9 +92,11 @@
       }
     }
 
-    this.formData = function() {
-      var rejected = consumed(this)
-      return rejected ? rejected : Promise.resolve(decode(this._body))
+    if (self.FormData) {
+      this.formData = function() {
+        var rejected = consumed(this)
+        return rejected ? rejected : Promise.resolve(decode(this._body))
+      }
     }
 
     this.json = function() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "private": true,
   "devDependencies": {
     "bower": "1.3.8",
+    "chai": "1.10.0",
     "jshint": "2.5.2",
-    "node-qunit-phantomjs": "0.2.2"
+    "mocha-phantomjs": "3.5.2",
+    "mocha": "2.1.0",
+    "phantomjs": "1.9.13"
   }
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -18,27 +18,11 @@
   "browser": true,
   "worker": true,
   "globals": {
-    "MockXHR": false,
-    "QUnit": false,
     "fetch": false,
     "Headers": false,
     "Request": false,
     "Response": false,
-    "module": false,
     "test": false,
-    "asyncTest": false,
-    "promiseTest": false,
-    "testDone": false,
-    "expect": false,
-    "start": false,
-    "stop": false,
-    "ok": false,
-    "equal": false,
-    "notEqual": false,
-    "deepEqual": false,
-    "notDeepEqual": false,
-    "strictEqual": false,
-    "notStrictEqual": false,
-    "raises": false
+    "assert": false
   }
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -22,6 +22,8 @@
     "Headers": false,
     "Request": false,
     "Response": false,
+    "mocha": false,
+    "chai": false,
     "suite": false,
     "test": false,
     "assert": false

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -22,6 +22,7 @@
     "Headers": false,
     "Request": false,
     "Response": false,
+    "suite": false,
     "test": false,
     "assert": false
   }

--- a/test/run.sh
+++ b/test/run.sh
@@ -12,3 +12,4 @@ server_pid=$!
 trap "kill $server_pid" INT EXIT
 
 node ./node_modules/.bin/mocha-phantomjs -s localToRemoteUrlAccessEnabled=true -s webSecurityEnabled=false "http://localhost:$port/test/test.html"
+node ./node_modules/.bin/mocha-phantomjs -s localToRemoteUrlAccessEnabled=true -s webSecurityEnabled=false "http://localhost:$port/test/test-worker.html"

--- a/test/run.sh
+++ b/test/run.sh
@@ -11,4 +11,4 @@ node ./test/server.js $port &>/dev/null &
 server_pid=$!
 trap "kill $server_pid" INT EXIT
 
-node ./node_modules/.bin/node-qunit-phantomjs "http://localhost:$port/test/test.html"
+node ./node_modules/.bin/mocha-phantomjs -s localToRemoteUrlAccessEnabled=true -s webSecurityEnabled=false "http://localhost:$port/test/test.html"

--- a/test/test-worker.html
+++ b/test/test-worker.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Fetch Worker Tests</title>
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../node_modules/mocha/mocha.js"></script>
+
+  <script>
+    mocha.setup('tdd')
+
+    var worker = new Worker('worker.js')
+
+    worker.addEventListener('message', function(e) {
+      switch (e.data.name) {
+        case 'pass':
+          test(e.data.title, function() {})
+          break
+        case 'pending':
+          test(e.data.title)
+          break
+        case 'fail':
+          test(e.data.title, function() {
+            var err = new Error(e.data.message)
+            err.stack = e.data.stack
+            throw err
+          })
+          break
+        case 'end':
+          if (self.mochaPhantomJS) {
+            mochaPhantomJS.run()
+          } else {
+            mocha.run()
+          }
+          break
+      }
+    })
+  </script>
+</body>
+</html>

--- a/test/test.html
+++ b/test/test.html
@@ -10,8 +10,8 @@
   <script src="../node_modules/chai/chai.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
   <script>
-    mocha.setup('tdd');
-    self.assert = chai.assert;
+    mocha.setup('tdd')
+    self.assert = chai.assert
   </script>
 
   <script src="../bower_components/es6-promise/promise.js"></script>
@@ -21,9 +21,9 @@
 
   <script>
     if (self.mochaPhantomJS) {
-      mochaPhantomJS.run();
+      mochaPhantomJS.run()
     } else {
-      mocha.run();
+      mocha.run()
     }
   </script>
 </body>

--- a/test/test.html
+++ b/test/test.html
@@ -2,28 +2,32 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Test Suite</title>
-  <link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css">
+  <title>Fetch Tests</title>
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 </head>
 <body>
-  <div id="qunit"></div>
-  <div id="qunit-fixture"></div>
+  <div id="mocha"></div>
+  <script src="../node_modules/chai/chai.js"></script>
+  <script src="../node_modules/mocha/mocha.js"></script>
+  <script>
+    mocha.setup('tdd');
+    self.assert = chai.assert;
+  </script>
+
   <script src="../bower_components/es6-promise/promise.js"></script>
   <script src="../fetch.js"></script>
-  <script src="../bower_components/qunit/qunit/qunit.js"></script>
+
+  <script src="test.js"></script>
+
   <script>
-    QUnit.promiseTest = function(testName, expected, callback) {
-      QUnit.test(testName, expected, function() {
-        stop();
-        Promise.resolve().then(callback).then(start, function(error) {
-          ok(false, error);
-          start();
-        });
-      });
+    mocha.checkLeaks();
+    //mocha.globals(['jQuery']);
+
+    if (self.mochaPhantomJS) {
+      mochaPhantomJS.run();
+    } else {
+      mocha.run();
     }
-    window.promiseTest = QUnit.promiseTest;
   </script>
-  <script>QUnit.config.testTimeout = 1000</script>
-  <script src="./test.js"></script>
 </body>
 </html>

--- a/test/test.html
+++ b/test/test.html
@@ -20,9 +20,6 @@
   <script src="test.js"></script>
 
   <script>
-    mocha.checkLeaks();
-    //mocha.globals(['jQuery']);
-
     if (self.mochaPhantomJS) {
       mochaPhantomJS.run();
     } else {

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,13 @@
-promiseTest('populates response body', 2, function() {
+test('populates response body', function() {
   return fetch('/hello').then(function(response) {
-    equal(response.status, 200)
+    assert.equal(response.status, 200)
     return response.text()
   }).then(function(body) {
-    equal(body, 'hi')
+    assert.equal(body, 'hi')
   })
 })
 
-promiseTest('sends request headers', 2, function() {
+test('sends request headers', function() {
   return fetch('/request', {
     headers: {
       'Accept': 'application/json',
@@ -16,236 +16,235 @@ promiseTest('sends request headers', 2, function() {
   }).then(function(response) {
     return response.json()
   }).then(function(json) {
-    equal(json.headers['accept'], 'application/json')
-    equal(json.headers['x-test'], '42')
+    assert.equal(json.headers['accept'], 'application/json')
+    assert.equal(json.headers['x-test'], '42')
   })
 })
 
-promiseTest('parses response headers', 2, function() {
+test('parses response headers', function() {
   return fetch('/headers?' + new Date().getTime()).then(function(response) {
-    equal(response.headers.get('Date'), 'Mon, 13 Oct 2014 21:02:27 GMT')
-    equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
+    assert.equal(response.headers.get('Date'), 'Mon, 13 Oct 2014 21:02:27 GMT')
+    assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
   })
 })
 
-promiseTest('resolves promise on 500 error', 2, function() {
+test('resolves promise on 500 error', function() {
   return fetch('/boom').then(function(response) {
-    equal(response.status, 500)
+    assert.equal(response.status, 500)
     return response.text()
   }).then(function(body) {
-    equal(body, 'boom')
+    assert.equal(body, 'boom')
   })
 })
 
-promiseTest('rejects promise for network error', 1, function() {
+test('rejects promise for network error', function() {
   return fetch('/error').then(function(response) {
-    ok(false, 'HTTP status ' + response.status + ' was treated as success')
-    start()
+    assert(false, 'HTTP status ' + response.status + ' was treated as success')
   }).catch(function(error) {
-    ok(error instanceof TypeError, 'Rejected with Error')
+    assert(error instanceof TypeError, 'Rejected with Error')
   })
 })
 
-promiseTest('handles 204 No Content response', 2, function() {
+test('handles 204 No Content response', function() {
   return fetch('/empty').then(function(response) {
-    equal(response.status, 204)
+    assert.equal(response.status, 204)
     return response.text()
   }).then(function(body) {
-    equal(body, '')
+    assert.equal(body, '')
   })
 })
 
-promiseTest('resolves text promise', 1, function() {
+test('resolves text promise', function() {
   return fetch('/hello').then(function(response) {
     return response.text()
   }).then(function(text) {
-    equal(text, 'hi')
+    assert.equal(text, 'hi')
   })
 })
 
 if (Response.prototype.formData) {
-  promiseTest('parses form encoded response', 1, function() {
+  test('parses form encoded response', function() {
     return fetch('/form').then(function(response) {
       return response.formData()
     }).then(function(form) {
-      ok(form instanceof FormData, 'Parsed a FormData object')
+      assert(form instanceof FormData, 'Parsed a FormData object')
     })
   })
 }
 
-promiseTest('parses json response', 2, function() {
+test('parses json response', function() {
   return fetch('/json').then(function(response) {
     return response.json()
   }).then(function(json) {
-    equal(json.name, 'Hubot')
-    equal(json.login, 'hubot')
+    assert.equal(json.name, 'Hubot')
+    assert.equal(json.login, 'hubot')
   })
 })
 
-promiseTest('handles json parse error', 2, function() {
+test('handles json parse error', function() {
   return fetch('/json-error').then(function(response) {
     return response.json()
   }).catch(function(error) {
-    ok(error instanceof Error, 'JSON exception is an Error instance')
-    ok(error.message, 'JSON exception has an error message')
+    assert(error instanceof Error, 'JSON exception is an Error instance')
+    assert(error.message, 'JSON exception has an error message')
   })
 })
 
 if (Response.prototype.blob) {
-  promiseTest('resolves blob promise', 2, function() {
+  test('resolves blob promise', function() {
     return fetch('/hello').then(function(response) {
       return response.blob()
     }).then(function(blob) {
-      ok(blob instanceof Blob, 'blob is a Blob instance')
-      equal(blob.size, 2)
+      assert(blob instanceof Blob, 'blob is a Blob instance')
+      assert.equal(blob.size, 2)
     })
   })
 }
 
-promiseTest('post sets content-type header', 2, function() {
+test('post sets content-type header', function() {
   return fetch('/request', {
     method: 'post',
     body: new FormData()
   }).then(function(response) {
     return response.json()
   }).then(function(json) {
-    equal(json.method, 'POST')
-    ok(/^multipart\/form-data;/.test(json.headers['content-type']))
+    assert.equal(json.method, 'POST')
+    assert(/^multipart\/form-data;/.test(json.headers['content-type']))
   })
 })
 
 if (Response.prototype.blob) {
-  promiseTest('rejects blob promise after body is consumed', 2, function() {
+  test('rejects blob promise after body is consumed', function() {
     return fetch('/hello').then(function(response) {
-      ok(response.blob, 'Body does not implement blob')
+      assert(response.blob, 'Body does not implement blob')
       response.blob()
       return response.blob()
     }).catch(function(error) {
-      ok(error instanceof TypeError, 'Promise rejected after body consumed')
+      assert(error instanceof TypeError, 'Promise rejected after body consumed')
     })
   })
 }
 
-promiseTest('rejects json promise after body is consumed', 2, function() {
+test('rejects json promise after body is consumed', function() {
   return fetch('/json').then(function(response) {
-    ok(response.json, 'Body does not implement json')
+    assert(response.json, 'Body does not implement json')
     response.json()
     return response.json()
   }).catch(function(error) {
-    ok(error instanceof TypeError, 'Promise rejected after body consumed')
+    assert(error instanceof TypeError, 'Promise rejected after body consumed')
   })
 })
 
-promiseTest('rejects text promise after body is consumed', 2, function() {
+test('rejects text promise after body is consumed', function() {
   return fetch('/hello').then(function(response) {
-    ok(response.text, 'Body does not implement text')
+    assert(response.text, 'Body does not implement text')
     response.text()
     return response.text()
   }).catch(function(error) {
-    ok(error instanceof TypeError, 'Promise rejected after body consumed')
+    assert(error instanceof TypeError, 'Promise rejected after body consumed')
   })
 })
 
 if (Response.prototype.formData) {
-  promiseTest('rejects formData promise after body is consumed', 2, function() {
+  test('rejects formData promise after body is consumed', function() {
     return fetch('/json').then(function(response) {
-      ok(response.formData, 'Body does not implement formData')
+      assert(response.formData, 'Body does not implement formData')
       response.formData()
       return response.formData()
     }).catch(function(error) {
-      ok(error instanceof TypeError, 'Promise rejected after body consumed')
+      assert(error instanceof TypeError, 'Promise rejected after body consumed')
     })
   })
 }
 
-promiseTest('supports HTTP PUT', 2, function() {
+test('supports HTTP PUT', function() {
   return fetch('/request', {
     method: 'put',
     body: 'name=Hubot'
   }).then(function(response) {
     return response.json()
   }).then(function(request) {
-    equal(request.method, 'PUT')
-    equal(request.data, 'name=Hubot')
+    assert.equal(request.method, 'PUT')
+    assert.equal(request.data, 'name=Hubot')
   })
 })
 
-promiseTest('supports HTTP PATCH', 2, function() {
+test('supports HTTP PATCH', function() {
   return fetch('/request', {
     method: 'PATCH',
     body: 'name=Hubot'
   }).then(function(response) {
     return response.json()
   }).then(function(request) {
-    equal(request.method, 'PATCH')
+    assert.equal(request.method, 'PATCH')
     if (/PhantomJS/.test(navigator.userAgent)) {
-      equal(request.data, '')
+      assert.equal(request.data, '')
     } else {
-      equal(request.data, 'name=Hubot')
+      assert.equal(request.data, 'name=Hubot')
     }
   })
 })
 
-promiseTest('supports HTTP DELETE', 2, function() {
+test('supports HTTP DELETE', function() {
   return fetch('/request', {
     method: 'delete',
   }).then(function(response) {
     return response.json()
   }).then(function(request) {
-    equal(request.method, 'DELETE')
-    equal(request.data, '')
+    assert.equal(request.method, 'DELETE')
+    assert.equal(request.data, '')
   })
 })
 
-promiseTest('handles 301 redirect response', 3, function() {
+test('handles 301 redirect response', function() {
   return fetch('/redirect/301').then(function(response) {
-    equal(response.status, 200)
-    equal(response.url ? new URL(response.url).pathname : null, '/hello')
+    assert.equal(response.status, 200)
+    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
     return response.text()
   }).then(function(body) {
-    equal(body, 'hi')
+    assert.equal(body, 'hi')
   })
 })
 
-promiseTest('handles 302 redirect response', 3, function() {
+test('handles 302 redirect response', function() {
   return fetch('/redirect/302').then(function(response) {
-    equal(response.status, 200)
-    equal(response.url ? new URL(response.url).pathname : null, '/hello')
+    assert.equal(response.status, 200)
+    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
     return response.text()
   }).then(function(body) {
-    equal(body, 'hi')
+    assert.equal(body, 'hi')
   })
 })
 
-promiseTest('handles 303 redirect response', 3, function() {
+test('handles 303 redirect response', function() {
   return fetch('/redirect/303').then(function(response) {
-    equal(response.status, 200)
-    equal(response.url ? new URL(response.url).pathname : null, '/hello')
+    assert.equal(response.status, 200)
+    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
     return response.text()
   }).then(function(body) {
-    equal(body, 'hi')
+    assert.equal(body, 'hi')
   })
 })
 
-promiseTest('handles 307 redirect response', 3, function() {
+test('handles 307 redirect response', function() {
   return fetch('/redirect/307').then(function(response) {
-    equal(response.status, 200)
-    equal(response.url ? new URL(response.url).pathname : null, '/hello')
+    assert.equal(response.status, 200)
+    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
     return response.text()
   }).then(function(body) {
-    equal(body, 'hi')
+    assert.equal(body, 'hi')
   })
 })
 
 // PhantomJS doesn't support 308 redirects
 if (!navigator.userAgent.match(/PhantomJS/)) {
-  promiseTest('handles 308 redirect response', 3, function() {
+  test('handles 308 redirect response', function() {
     return fetch('/redirect/308').then(function(response) {
-      equal(response.status, 200)
-    equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.equal(response.status, 200)
+    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
       return response.text()
     }).then(function(body) {
-      equal(body, 'hi')
+      assert.equal(body, 'hi')
     })
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -192,7 +192,8 @@ test('supports HTTP DELETE', function() {
   })
 })
 
-suite('Redirect', function() {
+// TODO: Avoid URL, not in PhantomJS
+;(self.URL ? suite : suite.skip)('Redirect', function() {
   test('handles 301 redirect response', function() {
     return fetch('/redirect/301').then(function(response) {
       assert.equal(response.status, 200)

--- a/test/test.js
+++ b/test/test.js
@@ -153,42 +153,65 @@ test('rejects text promise after body is consumed', function() {
   })
 })
 
-test('supports HTTP PUT', function() {
-  return fetch('/request', {
-    method: 'put',
-    body: 'name=Hubot'
-  }).then(function(response) {
-    return response.json()
-  }).then(function(request) {
-    assert.equal(request.method, 'PUT')
-    assert.equal(request.data, 'name=Hubot')
-  })
-})
-
-test('supports HTTP PATCH', function() {
-  return fetch('/request', {
-    method: 'PATCH',
-    body: 'name=Hubot'
-  }).then(function(response) {
-    return response.json()
-  }).then(function(request) {
-    assert.equal(request.method, 'PATCH')
-    if (/PhantomJS/.test(navigator.userAgent)) {
+suite('HTTP verbs', function() {
+  test('supports HTTP GET', function() {
+    return fetch('/request', {
+      method: 'get',
+      body: 'name=Hubot'
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'GET')
       assert.equal(request.data, '')
-    } else {
-      assert.equal(request.data, 'name=Hubot')
-    }
+    })
   })
-})
+    test('supports HTTP POST', function() {
+    return fetch('/request', {
+      method: 'post',
+      body: 'name=Hubot'
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'POST')
+      assert.equal(request.data, 'name=Hubot')
+    })
+  })
 
-test('supports HTTP DELETE', function() {
-  return fetch('/request', {
-    method: 'delete',
-  }).then(function(response) {
-    return response.json()
-  }).then(function(request) {
-    assert.equal(request.method, 'DELETE')
-    assert.equal(request.data, '')
+  test('supports HTTP PUT', function() {
+    return fetch('/request', {
+      method: 'put',
+      body: 'name=Hubot'
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'PUT')
+      assert.equal(request.data, 'name=Hubot')
+    })
+  })
+
+  var patchSupported = !/PhantomJS/.test(navigator.userAgent)
+
+  ;(patchSupported ? test : test.skip)('supports HTTP PATCH', function() {
+    return fetch('/request', {
+      method: 'PATCH',
+      body: 'name=Hubot'
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'PATCH')
+      assert.equal(request.data, 'name=Hubot')
+    })
+  })
+
+  test('supports HTTP DELETE', function() {
+    return fetch('/request', {
+      method: 'delete',
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'DELETE')
+      assert.equal(request.data, '')
+    })
   })
 })
 
@@ -234,16 +257,15 @@ suite('Redirect', function() {
     })
   })
 
-  // PhantomJS doesn't support 308 redirects
-  if (!navigator.userAgent.match(/PhantomJS/)) {
-    test('handles 308 redirect response', function() {
-      return fetch('/redirect/308').then(function(response) {
-        assert.equal(response.status, 200)
-        assert.match(response.url, /\/hello/)
-        return response.text()
-      }).then(function(body) {
-        assert.equal(body, 'hi')
-      })
+  var permanentRedirectSupported = !/PhantomJS/.test(navigator.userAgent)
+
+  ;(permanentRedirectSupported ? test : test.skip)('handles 308 redirect response', function() {
+    return fetch('/redirect/308').then(function(response) {
+      assert.equal(response.status, 200)
+      assert.match(response.url, /\/hello/)
+      return response.text()
+    }).then(function(body) {
+      assert.equal(body, 'hi')
     })
-  }
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,33 +1,3 @@
-test('populates response body', function() {
-  return fetch('/hello').then(function(response) {
-    assert.equal(response.status, 200)
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, 'hi')
-  })
-})
-
-test('sends request headers', function() {
-  return fetch('/request', {
-    headers: {
-      'Accept': 'application/json',
-      'X-Test': '42'
-    }
-  }).then(function(response) {
-    return response.json()
-  }).then(function(json) {
-    assert.equal(json.headers['accept'], 'application/json')
-    assert.equal(json.headers['x-test'], '42')
-  })
-})
-
-test('parses response headers', function() {
-  return fetch('/headers?' + new Date().getTime()).then(function(response) {
-    assert.equal(response.headers.get('Date'), 'Mon, 13 Oct 2014 21:02:27 GMT')
-    assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
-  })
-})
-
 test('resolves promise on 500 error', function() {
   return fetch('/boom').then(function(response) {
     assert.equal(response.status, 500)
@@ -45,115 +15,159 @@ test('rejects promise for network error', function() {
   })
 })
 
-test('handles 204 No Content response', function() {
-  return fetch('/empty').then(function(response) {
-    assert.equal(response.status, 204)
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, '')
-  })
-})
-
-test('resolves text promise', function() {
-  return fetch('/hello').then(function(response) {
-    return response.text()
-  }).then(function(text) {
-    assert.equal(text, 'hi')
-  })
-})
-
-test('parses json response', function() {
-  return fetch('/json').then(function(response) {
-    return response.json()
-  }).then(function(json) {
-    assert.equal(json.name, 'Hubot')
-    assert.equal(json.login, 'hubot')
-  })
-})
-
-test('handles json parse error', function() {
-  return fetch('/json-error').then(function(response) {
-    return response.json()
-  }).catch(function(error) {
-    assert(error instanceof Error, 'JSON exception is an Error instance')
-    assert(error.message, 'JSON exception has an error message')
-  })
-})
-
-;(Response.prototype.blob ? suite : suite.skip)('Blob', function() {
-  test('resolves blob promise', function() {
-    return fetch('/hello').then(function(response) {
-      return response.blob()
-    }).then(function(blob) {
-      assert(blob instanceof Blob, 'blob is a Blob instance')
-      assert.equal(blob.size, 2)
-    })
-  })
-
-  test('rejects blob promise after body is consumed', function() {
-    return fetch('/hello').then(function(response) {
-      assert(response.blob, 'Body does not implement blob')
-      response.blob()
-      return response.blob()
-    }).catch(function(error) {
-      assert(error instanceof TypeError, 'Promise rejected after body consumed')
-    })
-  })
-})
-
-;(Response.prototype.formData ? suite : suite.skip)('FormData', function() {
-  test('post sets content-type header', function() {
+// https://fetch.spec.whatwg.org/#request-class
+suite('Request', function() {
+  test('sends request headers', function() {
     return fetch('/request', {
-      method: 'post',
-      body: new FormData()
+      headers: {
+        'Accept': 'application/json',
+        'X-Test': '42'
+      }
     }).then(function(response) {
       return response.json()
     }).then(function(json) {
-      assert.equal(json.method, 'POST')
-      assert(/^multipart\/form-data;/.test(json.headers['content-type']))
-    })
-  })
-
-  test('rejects formData promise after body is consumed', function() {
-    return fetch('/json').then(function(response) {
-      assert(response.formData, 'Body does not implement formData')
-      response.formData()
-      return response.formData()
-    }).catch(function(error) {
-      assert(error instanceof TypeError, 'Promise rejected after body consumed')
-    })
-  })
-
-  test('parses form encoded response', function() {
-    return fetch('/form').then(function(response) {
-      return response.formData()
-    }).then(function(form) {
-      assert(form instanceof FormData, 'Parsed a FormData object')
+      assert.equal(json.headers['accept'], 'application/json')
+      assert.equal(json.headers['x-test'], '42')
     })
   })
 })
 
-test('rejects json promise after body is consumed', function() {
-  return fetch('/json').then(function(response) {
-    assert(response.json, 'Body does not implement json')
-    response.json()
-    return response.json()
-  }).catch(function(error) {
-    assert(error instanceof TypeError, 'Promise rejected after body consumed')
+// https://fetch.spec.whatwg.org/#response-class
+suite('Response', function() {
+  test('populates response body', function() {
+    return fetch('/hello').then(function(response) {
+      assert.equal(response.status, 200)
+      return response.text()
+    }).then(function(body) {
+      assert.equal(body, 'hi')
+    })
+  })
+
+  test('parses response headers', function() {
+    return fetch('/headers?' + new Date().getTime()).then(function(response) {
+      assert.equal(response.headers.get('Date'), 'Mon, 13 Oct 2014 21:02:27 GMT')
+      assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
+    })
   })
 })
 
-test('rejects text promise after body is consumed', function() {
-  return fetch('/hello').then(function(response) {
-    assert(response.text, 'Body does not implement text')
-    response.text()
-    return response.text()
-  }).catch(function(error) {
-    assert(error instanceof TypeError, 'Promise rejected after body consumed')
+// https://fetch.spec.whatwg.org/#body-mixin
+suite('Body mixin', function() {
+  ;(Response.prototype.blob ? suite : suite.skip)('blob', function() {
+    test('resolves blob promise', function() {
+      return fetch('/hello').then(function(response) {
+        return response.blob()
+      }).then(function(blob) {
+        assert(blob instanceof Blob, 'blob is a Blob instance')
+        assert.equal(blob.size, 2)
+      })
+    })
+
+    test('rejects blob promise after body is consumed', function() {
+      return fetch('/hello').then(function(response) {
+        assert(response.blob, 'Body does not implement blob')
+        response.blob()
+        return response.blob()
+      }).catch(function(error) {
+        assert(error instanceof TypeError, 'Promise rejected after body consumed')
+      })
+    })
+  })
+
+  ;(Response.prototype.formData ? suite : suite.skip)('formData', function() {
+    test('post sets content-type header', function() {
+      return fetch('/request', {
+        method: 'post',
+        body: new FormData()
+      }).then(function(response) {
+        return response.json()
+      }).then(function(json) {
+        assert.equal(json.method, 'POST')
+        assert(/^multipart\/form-data;/.test(json.headers['content-type']))
+      })
+    })
+
+    test('rejects formData promise after body is consumed', function() {
+      return fetch('/json').then(function(response) {
+        assert(response.formData, 'Body does not implement formData')
+        response.formData()
+        return response.formData()
+      }).catch(function(error) {
+        assert(error instanceof TypeError, 'Promise rejected after body consumed')
+      })
+    })
+
+    test('parses form encoded response', function() {
+      return fetch('/form').then(function(response) {
+        return response.formData()
+      }).then(function(form) {
+        assert(form instanceof FormData, 'Parsed a FormData object')
+      })
+    })
+  })
+
+  suite('json', function() {
+    test('parses json response', function() {
+      return fetch('/json').then(function(response) {
+        return response.json()
+      }).then(function(json) {
+        assert.equal(json.name, 'Hubot')
+        assert.equal(json.login, 'hubot')
+      })
+    })
+
+    test('rejects json promise after body is consumed', function() {
+      return fetch('/json').then(function(response) {
+        assert(response.json, 'Body does not implement json')
+        response.json()
+        return response.json()
+      }).catch(function(error) {
+        assert(error instanceof TypeError, 'Promise rejected after body consumed')
+      })
+    })
+
+    test('handles json parse error', function() {
+      return fetch('/json-error').then(function(response) {
+        return response.json()
+      }).catch(function(error) {
+        assert(error instanceof Error, 'JSON exception is an Error instance')
+        assert(error.message, 'JSON exception has an error message')
+      })
+    })
+  })
+
+  suite('text', function() {
+    test('handles 204 No Content response', function() {
+      return fetch('/empty').then(function(response) {
+        assert.equal(response.status, 204)
+        return response.text()
+      }).then(function(body) {
+        assert.equal(body, '')
+      })
+    })
+
+    test('resolves text promise', function() {
+      return fetch('/hello').then(function(response) {
+        return response.text()
+      }).then(function(text) {
+        assert.equal(text, 'hi')
+      })
+    })
+
+    test('rejects text promise after body is consumed', function() {
+      return fetch('/hello').then(function(response) {
+        assert(response.text, 'Body does not implement text')
+        response.text()
+        return response.text()
+      }).catch(function(error) {
+        assert(error instanceof TypeError, 'Promise rejected after body consumed')
+      })
+    })
   })
 })
 
-suite('HTTP verbs', function() {
+// https://fetch.spec.whatwg.org/#methods
+suite('Methods', function() {
   test('supports HTTP GET', function() {
     return fetch('/request', {
       method: 'get',
@@ -215,8 +229,8 @@ suite('HTTP verbs', function() {
   })
 })
 
-// TODO: Avoid URL, not in PhantomJS
-suite('Redirect', function() {
+// https://fetch.spec.whatwg.org/#atomic-http-redirect-handling
+suite('Atomic HTTP redirect handling', function() {
   test('handles 301 redirect response', function() {
     return fetch('/redirect/301').then(function(response) {
       assert.equal(response.status, 200)

--- a/test/test.js
+++ b/test/test.js
@@ -192,55 +192,57 @@ test('supports HTTP DELETE', function() {
   })
 })
 
-test('handles 301 redirect response', function() {
-  return fetch('/redirect/301').then(function(response) {
-    assert.equal(response.status, 200)
-    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, 'hi')
-  })
-})
-
-test('handles 302 redirect response', function() {
-  return fetch('/redirect/302').then(function(response) {
-    assert.equal(response.status, 200)
-    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, 'hi')
-  })
-})
-
-test('handles 303 redirect response', function() {
-  return fetch('/redirect/303').then(function(response) {
-    assert.equal(response.status, 200)
-    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, 'hi')
-  })
-})
-
-test('handles 307 redirect response', function() {
-  return fetch('/redirect/307').then(function(response) {
-    assert.equal(response.status, 200)
-    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
-    return response.text()
-  }).then(function(body) {
-    assert.equal(body, 'hi')
-  })
-})
-
-// PhantomJS doesn't support 308 redirects
-if (!navigator.userAgent.match(/PhantomJS/)) {
-  test('handles 308 redirect response', function() {
-    return fetch('/redirect/308').then(function(response) {
+suite('Redirect', function() {
+  test('handles 301 redirect response', function() {
+    return fetch('/redirect/301').then(function(response) {
       assert.equal(response.status, 200)
-    assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
     })
   })
-}
+
+  test('handles 302 redirect response', function() {
+    return fetch('/redirect/302').then(function(response) {
+      assert.equal(response.status, 200)
+      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      return response.text()
+    }).then(function(body) {
+      assert.equal(body, 'hi')
+    })
+  })
+
+  test('handles 303 redirect response', function() {
+    return fetch('/redirect/303').then(function(response) {
+      assert.equal(response.status, 200)
+      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      return response.text()
+    }).then(function(body) {
+      assert.equal(body, 'hi')
+    })
+  })
+
+  test('handles 307 redirect response', function() {
+    return fetch('/redirect/307').then(function(response) {
+      assert.equal(response.status, 200)
+      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      return response.text()
+    }).then(function(body) {
+      assert.equal(body, 'hi')
+    })
+  })
+
+  // PhantomJS doesn't support 308 redirects
+  if (!navigator.userAgent.match(/PhantomJS/)) {
+    test('handles 308 redirect response', function() {
+      return fetch('/redirect/308').then(function(response) {
+        assert.equal(response.status, 200)
+      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+        return response.text()
+      }).then(function(body) {
+        assert.equal(body, 'hi')
+      })
+    })
+  }
+})

--- a/test/test.js
+++ b/test/test.js
@@ -193,11 +193,11 @@ test('supports HTTP DELETE', function() {
 })
 
 // TODO: Avoid URL, not in PhantomJS
-;(self.URL ? suite : suite.skip)('Redirect', function() {
+suite('Redirect', function() {
   test('handles 301 redirect response', function() {
     return fetch('/redirect/301').then(function(response) {
       assert.equal(response.status, 200)
-      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
@@ -207,7 +207,7 @@ test('supports HTTP DELETE', function() {
   test('handles 302 redirect response', function() {
     return fetch('/redirect/302').then(function(response) {
       assert.equal(response.status, 200)
-      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
@@ -217,7 +217,7 @@ test('supports HTTP DELETE', function() {
   test('handles 303 redirect response', function() {
     return fetch('/redirect/303').then(function(response) {
       assert.equal(response.status, 200)
-      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
@@ -227,7 +227,7 @@ test('supports HTTP DELETE', function() {
   test('handles 307 redirect response', function() {
     return fetch('/redirect/307').then(function(response) {
       assert.equal(response.status, 200)
-      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+      assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
@@ -239,7 +239,7 @@ test('supports HTTP DELETE', function() {
     test('handles 308 redirect response', function() {
       return fetch('/redirect/308').then(function(response) {
         assert.equal(response.status, 200)
-      assert.equal(response.url ? new URL(response.url).pathname : null, '/hello')
+        assert.match(response.url, /\/hello/)
         return response.text()
       }).then(function(body) {
         assert.equal(body, 'hi')

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,39 @@
+importScripts('../node_modules/chai/chai.js')
+importScripts('../node_modules/mocha/mocha.js')
+
+mocha.setup('tdd')
+self.assert = chai.assert
+
+importScripts('../bower_components/es6-promise/promise.js')
+importScripts('../fetch.js')
+
+importScripts('test.js')
+
+function title(test) {
+  return test.fullTitle().replace(/#/g, '');
+}
+
+function reporter(runner) {
+  runner.on('pending', function(test){
+    self.postMessage({name: 'pending', title: title(test)});
+  });
+
+  runner.on('pass', function(test){
+    self.postMessage({name: 'pass', title: title(test)});
+  });
+
+  runner.on('fail', function(test, err){
+    self.postMessage({
+      name: 'fail',
+      title: title(test),
+      message: err.message,
+      stack: err.stack
+    });
+  });
+
+  runner.on('end', function(){
+    self.postMessage({name: 'end'});
+  });
+}
+
+mocha.reporter(reporter).run()


### PR DESCRIPTION
I still :heart: QUnit because its super derpy and has no features, but I think Mocha is a little better suite for the things I'm hitting on our test suite.

* First class promise support
* Can run in web workers
* Supports skip/pending tests. Useful for marking tests has not supported in phantomjs or in certain browsers.
* The phantomjs runner works.

/cc @dgraham 