### PR TITLE
Make Headers case insensitive though lowercasing.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -24,6 +24,7 @@
   }
 
   Headers.prototype.append = function(name, value) {
+    name = name.toLowerCase()
     var list = this.map[name]
     if (!list) {
       list = []
@@ -33,24 +34,24 @@
   }
 
   Headers.prototype['delete'] = function(name) {
-    delete this.map[name]
+    delete this.map[name.toLowerCase()]
   }
 
   Headers.prototype.get = function(name) {
-    var values = this.map[name]
+    var values = this.map[name.toLowerCase()]
     return values ? values[0] : null
   }
 
   Headers.prototype.getAll = function(name) {
-    return this.map[name] || []
+    return this.map[name.toLowerCase()] || []
   }
 
   Headers.prototype.has = function(name) {
-    return this.map.hasOwnProperty(name)
+    return this.map.hasOwnProperty(name.toLowerCase())
   }
 
   Headers.prototype.set = function(name, value) {
-    this.map[name] = [value]
+    this.map[name.toLowerCase()] = [value]
   }
 
   // Instead of iterable for now.

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,16 @@ test('rejects promise for network error', function() {
   })
 })
 
+// https://fetch.spec.whatwg.org/#headers-class
+suite('Headers', function() {
+  test('headers are case insensitve', function() {
+    var headers = new Headers({'Accept': 'application/json'})
+    assert.equal(headers.get('ACCEPT'), 'application/json')
+    assert.equal(headers.get('Accept'), 'application/json')
+    assert.equal(headers.get('accept'), 'application/json')
+  })
+})
+
 // https://fetch.spec.whatwg.org/#request-class
 suite('Request', function() {
   test('sends request headers', function() {


### PR DESCRIPTION
This implementation is not case preserving when iterating over a Headers object.

See: https://fetch.spec.whatwg.org/#concept-header-name