### PR TITLE
Check for xhr.response only when supported.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -199,7 +199,7 @@
           headers: headers(xhr),
           url: xhr.responseURL || xhr.getResponseHeader('X-Request-URL')
         }
-        resolve(new Response(blobSupport ? xhr.response : xhr.responseText, options))
+        resolve(new Response('response' in xhr ? xhr.response : xhr.responseText, options))
       }
 
       xhr.onerror = function() {


### PR DESCRIPTION
ref: https://github.com/github/fetch/commit/74fa62be3dba24ea77f87d7aa5ab00ab90685b83

The above commit added a check for blob support to access the `response` property of the xhr. While that works for most cases, I'd argue the availability of XMLHTTPRequest2 and Blob are orthogonal and be treated as such.

For a practical use case, I haven't found a great solution for mocking XHR2 requests (generally use [Sinon.JS](https://github.com/cjohansen/Sinon.JS/issues/569)). Without the proposed change, any call to get a response body would return `undefined`. You can also imagine that any consumer who polyfills `Blob` in IE9 will run into the same type of issue.

Is there any harm in checking property existence in this instance?