### PR TITLE
Fix typo in npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You'll also need a Promise polyfill for older browsers.
 $ bower install es6-promise
 ```
 
-This can be also be installed with `npm`.
+This can also be installed with `npm`.
 
 ```sh
 $ npm install whatwg-fetch --save


### PR DESCRIPTION
I was reading through the README and spotted this.