### PR TITLE
Declare deliberate "async=true" on XMLHttpRequest open

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -274,7 +274,7 @@
         reject(new TypeError('Network request failed'))
       }
 
-      xhr.open(self.method, self.url)
+      xhr.open(self.method, self.url, true)
       if ('responseType' in xhr && blobSupport) {
         xhr.responseType = 'blob'
       }


### PR DESCRIPTION
On some installs, both Firefox & Chrome throws:
```
"Fetch failed: " DOMException [InvalidAccessError]:
"A parameter or an operation is not supported by the underlying object"
```
Due to something like pre-set `async=false` (an overridden prototype, maybe?)
This fixes the above issue, and I don't see it introducing any problems.