### PR TITLE
Add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "whatwg-fetch",
   "version": "0.6.1",
+  "repository": "github/fetch",
   "main": "fetch.js",
   "devDependencies": {
     "bower": "1.3.8",


### PR DESCRIPTION
npm has a habit of complaining when things aren't to its liking, like a package.json that lacks a `repository` field.

This uses npm's special-for-github `username/repo` syntax to be concise.