### PR TITLE
Add a convenience `ok` getter on `Response`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -306,7 +306,7 @@
     this.type = 'default'
     this.url = null
     this.status = options.status
-    this.ok = this.status >= 200 && this.status < 300;
+    this.ok = this.status >= 200 && this.status < 300
     this.statusText = options.statusText
     this.headers = options.headers
     this.url = options.url || ''

--- a/fetch.js
+++ b/fetch.js
@@ -306,6 +306,7 @@
     this.type = 'default'
     this.url = null
     this.status = options.status
+    this.ok = this.status >= 200 && this.status < 300;
     this.statusText = options.statusText
     this.headers = options.headers
     this.url = options.url || ''

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,7 @@ function readBlobAsBytes(blob) {
 test('resolves promise on 500 error', function() {
   return fetch('/boom').then(function(response) {
     assert.equal(response.status, 500)
+    assert.equal(response.ok, false)
     return response.text()
   }).then(function(body) {
     assert.equal(body, 'boom')
@@ -149,6 +150,7 @@ suite('Response', function() {
   test('populates response body', function() {
     return fetch('/hello').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       return response.text()
     }).then(function(body) {
       assert.equal(body, 'hi')
@@ -455,6 +457,7 @@ suite('Atomic HTTP redirect handling', function() {
   test('handles 301 redirect response', function() {
     return fetch('/redirect/301').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
@@ -465,6 +468,7 @@ suite('Atomic HTTP redirect handling', function() {
   test('handles 302 redirect response', function() {
     return fetch('/redirect/302').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
@@ -475,6 +479,7 @@ suite('Atomic HTTP redirect handling', function() {
   test('handles 303 redirect response', function() {
     return fetch('/redirect/303').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
@@ -485,6 +490,7 @@ suite('Atomic HTTP redirect handling', function() {
   test('handles 307 redirect response', function() {
     return fetch('/redirect/307').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {
@@ -497,6 +503,7 @@ suite('Atomic HTTP redirect handling', function() {
   ;(permanentRedirectSupported ? test : test.skip)('handles 308 redirect response', function() {
     return fetch('/redirect/308').then(function(response) {
       assert.equal(response.status, 200)
+      assert.equal(response.ok, true)
       assert.match(response.url, /\/hello/)
       return response.text()
     }).then(function(body) {


### PR DESCRIPTION
[ https://github.com/whatwg/fetch/commit/e62f57b6c923f16e877ab56913a2a65388a7535a ]

Also wondering if also need to polyfill `ok` on the next version of Chrome where `fetch` might now be a partial implementation (sorry, google. my bad…)

---

Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1126483