### PR TITLE
Set withCredentials after xhr.open for IE10 compatibility

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -261,9 +261,6 @@
 
     return new Promise(function(resolve, reject) {
       var xhr = new XMLHttpRequest()
-      if (self.credentials === 'cors') {
-        xhr.withCredentials = true;
-      }
 
       function responseURL() {
         if ('responseURL' in xhr) {
@@ -299,6 +296,10 @@
       }
 
       xhr.open(self.method, self.url, true)
+
+      if (self.credentials === 'cors') {
+        xhr.withCredentials = true;
+      }
 
       if ('responseType' in xhr && support.blob) {
         xhr.responseType = 'blob'


### PR DESCRIPTION
See http://stackoverflow.com/questions/19666809/cors-withcredentials-support-limited

Might also fix https://github.com/github/fetch/issues/93 but can't confirm