### PR TITLE
Support RequireJS and Browserify (UMD)

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,9 +1,15 @@
-(function() {
+(function (root, factory) {
   'use strict';
-
-  if (self.fetch) {
-    return
+  /* global module, define */
+  if (typeof define === 'function' && define.amd) {
+    define([], factory)
+  } else if (typeof exports === 'object') {
+    module.exports = factory()
+  } else {
+    factory().polyfill()
   }
+}(this, function () {
+  'use strict';
 
   function normalizeName(name) {
     if (typeof name !== 'string') {
@@ -331,14 +337,34 @@
     this.url = options.url || ''
   }
 
-  Body.call(Response.prototype)
-
-  self.Headers = Headers;
-  self.Request = Request;
-  self.Response = Response;
-
-  self.fetch = function (url, options) {
+  function fetch (url, options) {
     return new Request(url, options).fetch()
   }
-  self.fetch.polyfill = true
-})();
+
+  fetch.polyfill = true
+
+  Body.call(Response.prototype)
+
+  function polyfill() {
+    /* global global */
+    var local = (typeof global !== 'undefined') ? global : self
+
+    if (local.fetch) {
+      return
+    }
+
+    local.Headers = Headers
+    local.Request = Request
+    local.Response = Response
+    local.fetch = fetch
+  }
+
+  return {
+    'Headers': Headers,
+    'Request': Request,
+    'Response': Response,
+    'fetch': fetch,
+    'polyfill': polyfill
+  };
+
+}));


### PR DESCRIPTION
The main idea behind this PR is to fully support UMD.
`fetch` can still be included manually:
```
<script src="fetch.js"></script>
<script>
  fetch('/users.html').then(function () { /* ... */ });
</script>
```
but now it can also be required in an AMD or CommonJS environment:
```
var fetch = require('whatwg-fetch').fetch;
fetch('/users.html').then(function () { /* ... */ });
```
In the second case `fetch` doesn't patch the global environment automatically, but this can be done by calling `polyfill` if necessary:

```
require('whatwg-fetch').polyfill();
fetch('/users.html').then(function () { /* ... */ });
```