### PR TITLE
Fix credentials include

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -261,9 +261,6 @@
 
     return new Promise(function(resolve, reject) {
       var xhr = new XMLHttpRequest()
-      if (self.credentials === 'cors') {
-        xhr.withCredentials = true;
-      }
 
       function responseURL() {
         if ('responseURL' in xhr) {
@@ -299,6 +296,10 @@
       }
 
       xhr.open(self.method, self.url, true)
+
+      if (self.credentials === 'cors') {
+        xhr.withCredentials = true;
+      }
 
       if ('responseType' in xhr && support.blob) {
         xhr.responseType = 'blob'

--- a/fetch.js
+++ b/fetch.js
@@ -297,7 +297,9 @@
 
       xhr.open(self.method, self.url, true)
 
-      if (self.credentials === 'cors') {
+      // Note: 'cors' credentials value is nonstandard and accepted for
+      // backwards compatibility with old versions of this polyfill.
+      if (self.credentials === 'cors' || self.credentials === 'include') {
         xhr.withCredentials = true;
       }
 


### PR DESCRIPTION
Fixes https://github.com/github/fetch/issues/109.

It appears that cross-domain requests are not currently tested by the suite. However, the [test for this case](https://github.com/github/fetch/blob/89b449384fe7e1858615d2ecf85c78802815d7bb/test/test.js#L664) was not previously running since it was passing `credentials: 'include'`. With this change, the code actually runs, which was causing an exception in PhantomJS (see "Set xhr.withCredentials after xhr.open called.").