### PR TITLE
Support of passing the 'Request' object to the 'fetch' function as a first argument.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -226,17 +226,18 @@
       input = {url: input}
     }
 
-    this.url = input.url;
+    this.url = input.url
     this.credentials = options.credentials || input.credentials || 'omit'
     this.headers = new Headers(options.headers || input.headers)
     this.method = normalizeMethod(options.method || input.method || 'GET')
     this.mode = options.mode || input.mode || null
     this.referrer = null
 
-    if ((this.method === 'GET' || this.method === 'HEAD') && options.body) {
+    var body = options.body || input._bodyInit
+    if ((this.method === 'GET' || this.method === 'HEAD') && body) {
       throw new TypeError('Body not allowed for GET or HEAD requests')
     }
-    this._initBody(options.body || input._bodyInit)
+    this._initBody(body)
   }
 
   function decode(body) {

--- a/fetch.js
+++ b/fetch.js
@@ -338,10 +338,13 @@
   self.Response = Response;
 
   self.fetch = function (input, options) {
+    var url;
     if (input instanceof Request) {
-      if (input.bodyUsed === true) throw TypeError('Body has already been used');
+      if (input.bodyUsed === true) {
+        throw new TypeError('Body has already been used');
+      }
 
-      var url = input.url;
+      url = input.url;
       options = options || {};
       options.credentials = options.credentials || input.credentials;
       options.headers = options.headers || input.headers;
@@ -350,7 +353,7 @@
       options.body = options.body || input.body;
     }
     else {
-      var url = input;
+      url = input;
     }
 
     return new Request(url, options).fetch()

--- a/fetch.js
+++ b/fetch.js
@@ -337,7 +337,22 @@
   self.Request = Request;
   self.Response = Response;
 
-  self.fetch = function (url, options) {
+  self.fetch = function (input, options) {
+    if (input instanceof Request) {
+      if (input.bodyUsed === true) throw TypeError('Body has already been used');
+
+      var url = input.url;
+      options = options || {};
+      options.credentials = options.credentials || input.credentials;
+      options.headers = options.headers || input.headers;
+      options.method = options.method || input.method;
+      options.mode = options.mode || input.mode;
+      options.body = options.body || input.body;
+    }
+    else {
+      var url = input;
+    }
+
     return new Request(url, options).fetch()
   }
   self.fetch.polyfill = true

--- a/fetch.js
+++ b/fetch.js
@@ -350,7 +350,7 @@
       options.headers = options.headers || input.headers;
       options.method = options.method || input.method;
       options.mode = options.mode || input.mode;
-      options.body = options.body || input.body;
+      options.body = options.body || input._bodyInit;
     }
     else {
       url = input;


### PR DESCRIPTION
The specification allows us to pass not only the URL as a first argument of the 'fetch' function but also the 'Request' object. This behavior has already been implemented in the actual version of Firefox.