### PR TITLE
Return early if self is undefined

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  if (self.fetch) {
+  if (typeof self === 'undefined' || self.fetch) {
     return
   }
 


### PR DESCRIPTION
Return early if self is undefined, for environments that do not define 'self' (an example would be running a browserified script using ReactJS.NET.) This prevents a ReferenceError from occurring.