### PR TITLE
reject when request method is not a listed method

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -212,10 +212,7 @@
 
   function normalizeMethod(method) {
     var upcased = method.toUpperCase()
-    if (methods.indexOf(upcased) === -1) {
-      throw new TypeError('Method not allowed, must be one of ' + methods.join(', '))
-    }
-    return upcased;
+    return (methods.indexOf(upcased) > -1) ? upcased : method
   }
 
   function Request(url, options) {
@@ -266,6 +263,10 @@
       var xhr = new XMLHttpRequest()
       if (self.credentials === 'cors') {
         xhr.withCredentials = true;
+      }
+
+      if (methods.indexOf(self.method) === -1) {
+        reject(new TypeError('Method not allowed, must be one of ' + methods.join(', ')))
       }
 
       function responseURL() {

--- a/fetch.js
+++ b/fetch.js
@@ -212,7 +212,10 @@
 
   function normalizeMethod(method) {
     var upcased = method.toUpperCase()
-    return (methods.indexOf(upcased) > -1) ? upcased : method
+    if (methods.indexOf(upcased) === -1) {
+      throw new TypeError('Method not allowed, must be one of ' + methods.join(', '))
+    }
+    return upcased;
   }
 
   function Request(url, options) {

--- a/fetch.js
+++ b/fetch.js
@@ -225,9 +225,14 @@
     this.mode = options.mode || null
     this.referrer = null
 
+    if (!options.constructedWithFetch && methods.indexOf(this.method) === -1) {
+      throw new TypeError('Method "' + this.method + '" not allowed, must be one of ' + methods.join(', '))
+    }
+
     if ((this.method === 'GET' || this.method === 'HEAD') && options.body) {
       throw new TypeError('Body not allowed for GET or HEAD requests')
     }
+
     this._initBody(options.body)
   }
 
@@ -266,7 +271,7 @@
       }
 
       if (methods.indexOf(self.method) === -1) {
-        reject(new TypeError('Method not allowed, must be one of ' + methods.join(', ')))
+        reject(new TypeError('Method "' + self.method + '" not allowed, must be one of ' + methods.join(', ')))
       }
 
       function responseURL() {
@@ -342,6 +347,8 @@
   self.Response = Response;
 
   self.fetch = function (url, options) {
+    options = options || {}
+    options.constructedWithFetch = true;
     return new Request(url, options).fetch()
   }
   self.fetch.polyfill = true

--- a/test/test.js
+++ b/test/test.js
@@ -139,11 +139,34 @@ suite('Request', function() {
     assert.equal(request.url, 'https://fetch.spec.whatwg.org/')
   })
 
-  test('throws TypeError on invalid method', function() {
+  test('throws TypeError on invalid method CONNECT', function() {
     assert.throw(function() {
       new Request('/request', {
-        method: 'trace',
-        body: 'invalid'
+        method: 'CONNECT'
+      })
+    }, TypeError)
+  })
+
+  test('throws TypeError on invalid method TRACE', function() {
+    assert.throw(function() {
+      new Request('/request', {
+        method: 'TRACE'
+      })
+    }, TypeError)
+  })
+
+  test('throws TypeError on invalid method TRACK', function() {
+    assert.throw(function() {
+      new Request('/request', {
+        method: 'TRACK'
+      })
+    }, TypeError)
+  })
+
+  test('throws TypeError on methods that do not exist in fetch library', function() {
+    assert.throw(function() {
+      new Request('/request', {
+        method: 'FAKEMETHOD'
       })
     }, TypeError)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -526,22 +526,36 @@ suite('Methods', function() {
     })
   })
 
-  test('rejects forbidden methods CONNECT,TRACE,TRACK', function() {
-    ['CONNECT','TRACE','TRACK'].forEach(function(method) {
-      assert.throw(function() {
-        return fetch('/request', {
-          method: method,
-        })
-      }, TypeError)
-    });
+  test('rejects forbidden method CONNECT', function() {
+    return fetch('/request', { method: 'CONNECT' }).then(function() {
+      assert(false, 'HTTP request for forbidden method was treated as success')
+    }).catch(function(error) {
+      assert(error instanceof TypeError, 'Rejected with Error')
+    })
+  })
+
+  test('rejects forbidden method TRACE', function() {
+    return fetch('/request', { method: 'TRACE' }).then(function() {
+      assert(false, 'HTTP request for forbidden method was treated as success')
+    }).catch(function(error) {
+      assert(error instanceof TypeError, 'Rejected with Error')
+    })
+  })
+
+  test('rejects forbidden method TRACK', function() {
+    return fetch('/request', { method: 'TRACK' }).then(function() {
+      assert(false, 'HTTP request for forbidden method was treated as success')
+    }).catch(function(error) {
+      assert(error instanceof TypeError, 'Rejected with Error')
+    })
   })
 
   test('rejects methods that do not exist in fetch library', function() {
-    assert.throw(function() {
-      return fetch('/request', {
-        method: 'fakemethod',
-      })
-    }, TypeError)
+    return fetch('/request', { method: 'FAKEMETHOD'}).then(function() {
+      assert(false, 'HTTP request for non-existing method was treated as success')
+    }).catch(function(error) {
+      assert(error instanceof TypeError, 'Rejected with Error')
+    })
   })
 
 })

--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,15 @@ suite('Request', function() {
     assert.equal(request.url, 'https://fetch.spec.whatwg.org/')
   })
 
+  test('throws TypeError on invalid method', function() {
+    assert.throw(function() {
+      new Request('/request', {
+        method: 'trace',
+        body: 'invalid'
+      })
+    }, TypeError)
+  })
+
   // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
   suite('BodyInit extract', function() {
     ;(Request.prototype.blob ? suite : suite.skip)('type Blob', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -525,6 +525,25 @@ suite('Methods', function() {
       assert.equal(request.data, '')
     })
   })
+
+  test('rejects forbidden methods CONNECT,TRACE,TRACK', function() {
+    ['CONNECT','TRACE','TRACK'].forEach(function(method) {
+      assert.throw(function() {
+        return fetch('/request', {
+          method: method,
+        })
+      }, TypeError)
+    });
+  })
+
+  test('rejects methods that do not exist in fetch library', function() {
+    assert.throw(function() {
+      return fetch('/request', {
+        method: 'fakemethod',
+      })
+    }, TypeError)
+  })
+
 })
 
 // https://fetch.spec.whatwg.org/#atomic-http-redirect-handling


### PR DESCRIPTION
This covers step 20 on Request initialization:

> If init's method member is present, let method be it and run these substeps:
>    If method is not a method or method is a forbidden method, throw a TypeError. 