### PR TITLE
Implement Headers#forEach correctly

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -74,7 +74,9 @@
 
   Headers.prototype.forEach = function(callback) {
     Object.getOwnPropertyNames(this.map).forEach(function(name) {
-      callback(name, this.map[name])
+      this.map[name].forEach(function(value) {
+        callback(value, name, this)
+      }, this)
     }, this)
   }
 
@@ -320,10 +322,8 @@
         xhr.responseType = 'blob'
       }
 
-      request.headers.forEach(function(name, values) {
-        values.forEach(function(value) {
-          xhr.setRequestHeader(name, value)
-        })
+      request.headers.forEach(function(value, name) {
+        xhr.setRequestHeader(name, value)
       })
 
       xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)

--- a/fetch.js
+++ b/fetch.js
@@ -72,12 +72,10 @@
     this.map[normalizeName(name)] = [normalizeValue(value)]
   }
 
-  // Instead of iterable for now.
   Headers.prototype.forEach = function(callback) {
-    var self = this
     Object.getOwnPropertyNames(this.map).forEach(function(name) {
-      callback(name, self.map[name])
-    })
+      callback(name, this.map[name])
+    }, this)
   }
 
   function consumed(body) {

--- a/fetch.js
+++ b/fetch.js
@@ -72,10 +72,10 @@
     this.map[normalizeName(name)] = [normalizeValue(value)]
   }
 
-  Headers.prototype.forEach = function(callback) {
+  Headers.prototype.forEach = function(callback, thisArg) {
     Object.getOwnPropertyNames(this.map).forEach(function(name) {
       this.map[name].forEach(function(value) {
-        callback(value, name, this)
+        callback.call(thisArg, value, name, this)
       }, this)
     }, this)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,13 @@ suite('Headers', function() {
     assert.deepEqual({key: 'accept', value: 'text/plain', object: headers}, results[1])
     assert.deepEqual({key: 'content-type', value: 'text/html', object: headers}, results[2])
   })
+  test('forEach accepts second thisArg argument', function() {
+    var headers = new Headers({'Accept': 'application/json'})
+    var thisArg = 42
+    headers.forEach(function() {
+      assert.equal(this, thisArg)
+    }, thisArg)
+  })
  })
 
 // https://fetch.spec.whatwg.org/#request-class

--- a/test/test.js
+++ b/test/test.js
@@ -128,6 +128,22 @@ suite('Headers', function() {
       headers.set({field: 'value'}, 'application/json');
     }, TypeError)
   })
+  test('is iterable with forEach', function() {
+    var headers = new Headers()
+    headers.append('Accept', 'application/json')
+    headers.append('Accept', 'text/plain')
+    headers.append('Content-Type', 'text/html')
+
+    var results = []
+    headers.forEach(function(value, key, object) {
+      results.push({value: value, key: key, object: object})
+    })
+
+    assert.equal(results.length, 3)
+    assert.deepEqual({key: 'accept', value: 'application/json', object: headers}, results[0])
+    assert.deepEqual({key: 'accept', value: 'text/plain', object: headers}, results[1])
+    assert.deepEqual({key: 'content-type', value: 'text/html', object: headers}, results[2])
+  })
  })
 
 // https://fetch.spec.whatwg.org/#request-class


### PR DESCRIPTION
Changes the argument list passed into Headers#forEach to match the [iterable spec](http://heycam.github.io/webidl/#idl-iterable). Thanks for the link, @domenic.

Fixes #149.