### PR TITLE
Properly convert undefined/null header values to strings.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -7,7 +7,7 @@
 
   function normalizeName(name) {
     if (typeof name !== 'string') {
-      name = name.toString();
+      name = String(name)
     }
     if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
       throw new TypeError('Invalid character in header field name')
@@ -17,7 +17,7 @@
 
   function normalizeValue(value) {
     if (typeof value !== 'string') {
-      value = value.toString();
+      value = String(value)
     }
     return value
   }

--- a/test/test.js
+++ b/test/test.js
@@ -128,7 +128,9 @@ suite('Headers', function() {
   test('converts field value to string on set and get', function() {
     var headers = new Headers()
     headers.set('Content-Type', 1)
+    headers.set('X-CSRF-Token', undefined);
     assert.equal(headers.get('Content-Type'), '1')
+    assert.equal(headers.get('X-CSRF-Token'), 'undefined')
   })
   test('throws TypeError on invalid character in field name', function() {
     assert.throws(function() { new Headers({'<Accept>': ['application/json']}) }, TypeError)


### PR DESCRIPTION
In sending undefined/null header values with the fetch polyfill, I was getting an error:

```javascript
TypeError: 'undefined' is not an object (evaluating 'value.toString')

at normalizeValue (fetch.js:20:21)
    at Headers.append (fetch.js:42:14)
    at Headers.<anonymous> (fetch.js:30:15)
    at Array.forEach (native)
    at new Headers (fetch.js:29:45)
    at new Request (fetch.js:25:21)
    at self.fetch (fetch.js:273:18)
```

I tested this against the native window.fetch implementation in Chrome 43.0.2357.81 and observed that primitive values were handled fine when set as request header values. Using string concatenation for string conversion - over `toString` (as noted in [Axel Rauschmeyer's article on the subject](http://www.2ality.com/2012/03/converting-to-string.html)) - brings parity between the two implementations in this regard.