### PR TITLE
Fix tests in Firefox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
     - PHANTOMJS=1
     - SAUCE_PLATFORM="Windows 7" SAUCE_BROWSER="googlechrome" SAUCE_VERSION=""
+    - SAUCE_PLATFORM="Windows 7" SAUCE_BROWSER="firefox" SAUCE_VERSION=""
     - SAUCE_PLATFORM="Windows 7" SAUCE_BROWSER="internet explorer" SAUCE_VERSION="11"
     - SAUCE_PLATFORM="Windows 7" SAUCE_BROWSER="internet explorer" SAUCE_VERSION="10"
     - SAUCE_PLATFORM="Windows 7" SAUCE_BROWSER="internet explorer" SAUCE_VERSION="9"

--- a/fetch.js
+++ b/fetch.js
@@ -186,7 +186,9 @@
     }
 
     this.json = function() {
-      return this.text().then(JSON.parse)
+      return this.text().then(function(text) {
+        return JSON.parse(text)
+      })
     }
 
     return this


### PR DESCRIPTION
1. ~~As mentioned in #156, the global error handler is catching errors thrown in promise fulfillment. To circumvent this, where faulty JSON parsing is expected, temporarily remove the mocha runner uncaught exception handler.~~

2. Properly passes an error to the rejection handler for `.json`. Resolving with `JSON.parse` (by reference) rather than invoking it in a new function results in the rejection callback receiving an `NS_ERROR_UNEXPECTED` exception (not an instance of an `Error`) rather than a `JSON.parse` `SyntaxError` instance.