### PR TITLE
Opt into new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 before_script: make
 script: make test


### PR DESCRIPTION
Docker-based infrastructure usually has faster build times due to virtually no queue waiting time.