### PR TITLE
Improve documentation for `fetch` caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,27 +123,29 @@ ways that bear keeping in mind:
 
 #### Handling HTTP error statuses
 
-This causes `fetch` to behave like jQuery's `$.ajax` by rejecting the `Promise`
-on HTTP failure status codes like 404, 500, etc. The response `Promise` is
-resolved only on successful, 200 level, status codes.
+To have `fetch` Promise reject on HTTP error statuses, i.e. on any non-2xx
+status, define a custom response handler:
 
 ```javascript
-function status(response) {
+function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response
+  } else {
+    var error = new Error(response.statusText)
+    error.response = response
+    throw error
   }
-  throw new Error(response.statusText)
 }
 
-function json(response) {
+function parseJSON(response) {
   return response.json()
 }
 
 fetch('/users')
-  .then(status)
-  .then(json)
-  .then(function(json) {
-    console.log('request succeeded with json response', json)
+  .then(checkStatus)
+  .then(parseJSON)
+  .then(function(data) {
+    console.log('request succeeded with JSON response', data)
   }).catch(function(error) {
     console.log('request failed', error)
   })

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fetch('/users.json').then(function(response) {
 ```javascript
 var form = document.querySelector('form')
 
-fetch('/create', {
+fetch('/users', {
   method: 'post',
   body: new FormData(form)
 })

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fetch('/users.json').then(function(response) {
 ```javascript
 var form = document.querySelector('form')
 
-fetch('/query', {
+fetch('/create', {
   method: 'post',
   body: new FormData(form)
 })

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ fetch('/users', {
 ```javascript
 var input = document.querySelector('input[type="file"]')
 
-var form = new FormData()
-form.append('file', input.files[0])
-form.append('user', 'hubot')
+var data = new FormData()
+data.append('file', input.files[0])
+data.append('user', 'hubot')
 
 fetch('/avatars', {
   method: 'post',
-  body: form
+  body: data
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ fetch('/users')
 
 #### Sending cookies
 
-To have `fetch` automatically use cookies for the current domain, the
-`credentials` option must be provided:
+To automatically send cookies for the current domain, the `credentials` option
+must be provided:
 
 ```javascript
 fetch('/users', {

--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ This option makes `fetch` behave similar to XMLHttpRequest with regards to
 cookies. Otherwise, cookies won't get sent, resulting in these requests not
 preserving the authentication session.
 
+#### Receiving cookies
+
+Like with XMLHttpRequest, the `Set-Cookie` response header returned from the
+server is a [forbidden header name][] and therefore can't be programatically
+read with `response.headers.get()`. Instead, it's the browser's responsibility
+to handle new cookies being set (if applicable to the current URL). Unless they
+are HTTP-only, new cookies will be available through `document.cookie`.
+
+  [forbidden header name]: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+
 #### Obtaining the Response URL
 
 Due to limitations of XMLHttpRequest, the `response.url` value might not be

--- a/README.md
+++ b/README.md
@@ -108,7 +108,20 @@ fetch('/avatars', {
 })
 ```
 
-### Success and error handlers
+### Caveats
+
+The `fetch` specification differs from other ajax implementations in mainly two
+ways that bear keeping in mind:
+
+* The Promise returned from `fetch()` **won't reject on HTTP error status**
+  even if the response is a HTTP 404 or 500. Instead, it will resolve normally,
+  and it will only reject on network failure, or if anything prevented the
+  request from completing.
+
+* By default, `fetch` **won't send any cookies** to the server, resulting in
+  unauthenticated requests if the site relies on maintaining a user session.
+
+#### Handling HTTP error statuses
 
 This causes `fetch` to behave like jQuery's `$.ajax` by rejecting the `Promise`
 on HTTP failure status codes like 404, 500, etc. The response `Promise` is
@@ -136,7 +149,22 @@ fetch('/users')
   })
 ```
 
-### Response URL caveat
+#### Sending cookies
+
+To have `fetch` automatically use cookies for the current domain, the
+`credentials` option must be provided:
+
+```javascript
+fetch('/users', {
+  credentials: 'same-origin'
+})
+```
+
+This option makes `fetch` behave similar to XMLHttpRequest with regards to
+cookies. Otherwise, cookies won't get sent, resulting in these requests not
+preserving the authentication session.
+
+#### Obtaining the Response URL
 
 The `Response` object has a URL attribute for the final responded resource.
 Usually this is the same as the `Request` url, but in the case of a redirect,

--- a/README.md
+++ b/README.md
@@ -168,20 +168,20 @@ preserving the authentication session.
 
 #### Obtaining the Response URL
 
-The `Response` object has a URL attribute for the final responded resource.
-Usually this is the same as the `Request` url, but in the case of a redirect,
-its all transparent. Newer versions of XHR include a `responseURL` attribute
-that returns this value. But not every browser supports this. The compromise
-requires setting a special server side header to tell the browser what URL it
-just requested (yeah, I know browsers).
+Due to limitations of XMLHttpRequest, the `response.url` value might not be
+reliable after HTTP redirects on older browsers.
+
+The solution is to configure the server to set the response HTTP header
+`X-Request-URL` to the current URL after any redirect that might have happened.
+It should be safe to set it unconditionally.
 
 ``` ruby
+# Ruby on Rails controller example
 response.headers['X-Request-URL'] = request.url
 ```
 
-If you want `response.url` to be reliable, you'll want to set this header. The
-day that you ditch this polyfill and use native fetch only, you can remove the
-header hack.
+This server workaround is necessary if you need reliable `response.url` in
+Firefox < 32, Chrome < 37, Safari, or IE.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ fetch('/avatars', {
 
 ### Caveats
 
-The `fetch` specification differs from other ajax implementations in mainly two
-ways that bear keeping in mind:
+The `fetch` specification differs from `jQuery.ajax()` in mainly two ways that
+bear keeping in mind:
 
 * The Promise returned from `fetch()` **won't reject on HTTP error status**
   even if the response is a HTTP 404 or 500. Instead, it will resolve normally,


### PR DESCRIPTION
* Added caveat about cookies
* Revamped HTTP error handling
* Simpler `request.url` workaround explanation