### PR TITLE
Bail if `self` does not exist

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
 
-  if (self.fetch) {
+  if (typeof self === 'undefined' || self.fetch) {
     return
   }
 


### PR DESCRIPTION
- Exit out of attempting to polyfill when `self` does not exist.

Context: We're prerendering React components on the server. While `fetch` won't actually be executed, it throws an error because it's looking for `self`, which does not exist in the server environment.

This is not an attempt to make it run in node, but to make it return without throwing an error.