### PR TITLE
Allow passing a Request instance to Request constructor

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -209,7 +209,9 @@
       }
       this.url = input.url
       this.credentials = input.credentials
-      if (!options.headers) this.headers = new Headers(input.headers)
+      if (!options.headers) {
+        this.headers = new Headers(input.headers)
+      }
       this.method = input.method
       this.mode = input.mode
       if (!body) {
@@ -221,7 +223,9 @@
     }
 
     this.credentials = options.credentials || this.credentials || 'omit'
-    if (options.headers || !this.headers) this.headers = new Headers(options.headers)
+    if (options.headers || !this.headers) {
+      this.headers = new Headers(options.headers)
+    }
     this.method = normalizeMethod(options.method || this.method || 'GET')
     this.mode = options.mode || this.mode || null
     this.referrer = null

--- a/fetch.js
+++ b/fetch.js
@@ -200,20 +200,36 @@
     return (methods.indexOf(upcased) > -1) ? upcased : method
   }
 
-  function Request(url, options) {
+  function Request(input, options) {
     options = options || {}
-    this.url = url
+    var body = options.body
+    if (Request.prototype.isPrototypeOf(input)) {
+      if (input.bodyUsed) {
+        throw new TypeError('Already read')
+      }
+      this.url = input.url
+      this.credentials = input.credentials
+      if (!options.headers) this.headers = new Headers(input.headers)
+      this.method = input.method
+      this.mode = input.mode
+      if (!body) {
+        body = input._bodyInit
+        input.bodyUsed = true
+      }
+    } else {
+      this.url = input
+    }
 
-    this.credentials = options.credentials || 'omit'
-    this.headers = new Headers(options.headers)
-    this.method = normalizeMethod(options.method || 'GET')
-    this.mode = options.mode || null
+    this.credentials = options.credentials || this.credentials || 'omit'
+    if (options.headers || !this.headers) this.headers = new Headers(options.headers)
+    this.method = normalizeMethod(options.method || this.method || 'GET')
+    this.mode = options.mode || this.mode || null
     this.referrer = null
 
-    if ((this.method === 'GET' || this.method === 'HEAD') && options.body) {
+    if ((this.method === 'GET' || this.method === 'HEAD') && body) {
       throw new TypeError('Body not allowed for GET or HEAD requests')
     }
-    this._initBody(options.body)
+    this._initBody(body)
   }
 
   function decode(body) {
@@ -265,7 +281,6 @@
   self.Response = Response;
 
   self.fetch = function(input, init) {
-    // TODO: Request constructor should accept input, init
     var request
     if (Request.prototype.isPrototypeOf(input) && !init) {
       request = input

--- a/test/test.js
+++ b/test/test.js
@@ -507,7 +507,11 @@ suite('Body mixin', function() {
         response.formData()
         return response.formData()
       }).catch(function(error) {
-        assert(error instanceof TypeError, 'Promise rejected after body consumed')
+        if (error instanceof chai.AssertionError) {
+          throw error
+        } else {
+          assert(error instanceof TypeError, 'Promise rejected after body consumed')
+        }
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -265,7 +265,7 @@ suite('Request', function() {
     })
   })
 
-  test('construct with used Request body', function() {
+  ;(/Chrome\//.test(navigator.userAgent) ? test.skip : test)('construct with used Request body', function() {
     var request1 = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',
       body: 'I work out'

--- a/test/test.js
+++ b/test/test.js
@@ -221,9 +221,9 @@ suite('Request', function() {
       assert.equal(request2.headers.get('content-type'), 'text/plain')
 
       return request1.text().then(function() {
-        assert(false, "original request's body should have been consumed")
+        assert(false, 'original request body should have been consumed')
       }, function(error) {
-        assert(error instanceof TypeError, "expected TypeError for already read body")
+        assert(error instanceof TypeError, 'expected TypeError for already read body')
       })
     })
   })


### PR DESCRIPTION
I tried to match the spec as closely as possible. This should also make it possible to use `fetch(request, options)` invocation.

Fixes #177

/cc @dgraham @cesarandreu