### PR TITLE
Fixing the `credentials` option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ must be provided:
 
 ```javascript
 fetch('/users', {
-  credentials: 'same-origin'
+  credentials: 'include'
 })
 ```
 


### PR DESCRIPTION
According the the code, 'same-origin' is not used but 'include' results in the underlying `XMLHttpRequest`'s `withCredentials` being set to _true_.