### PR TITLE
Improve error messaging in case of failed network request

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -311,7 +311,13 @@
       xhr.onload = function() {
         var status = (xhr.status === 1223) ? 204 : xhr.status
         if (status < 100 || status > 599) {
-          reject(new TypeError('Network request failed'))
+          var msg = 'Network request failed'
+          if (xhr.responseText) {
+            msg += ' ("' + xhr.responseText + '")'
+          } else {
+            msg += ' (no other details)'
+          }
+          reject(new TypeError(msg))
           return
         }
         var options = {


### PR DESCRIPTION
Might save beginners quite a bit of head-scratching time when they try to POST w/out setting the header to the correct content type.