### PR TITLE
Support Response.error() and Response.redirect()

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -280,6 +280,22 @@
 
   Body.call(Response.prototype)
 
+  Response.error = function() {
+    var response = new Response(null, {status: 0, statusText: ''})
+    response.type = 'error'
+    return response
+  }
+
+  var redirectStatuses = [301, 302, 303, 307, 308]
+
+  Response.redirect = function(url, status) {
+    if (redirectStatuses.indexOf(status) === -1) {
+      throw new RangeError('Invalid status code')
+    }
+
+    return new Response(null, {status: status, headers: {location: url}})
+  }
+
   self.Headers = Headers;
   self.Request = Request;
   self.Response = Response;

--- a/test/test.js
+++ b/test/test.js
@@ -376,6 +376,21 @@ suite('Response', function() {
       return json;
     })
   })
+
+  test('error creates error Response', function() {
+    var r = Response.error()
+    assert(r instanceof Response)
+    assert.equal(r.status, 0)
+    assert.equal(r.statusText, '')
+    assert.equal(r.type, 'error')
+  })
+
+  test('redirect creates redirect Response', function() {
+    var r = Response.redirect('/hello', 301)
+    assert(r instanceof Response);
+    assert.equal(r.status, 301)
+    assert.equal(r.headers.get('Location', '/hello'), '/hello')
+  })
 })
 
 // https://fetch.spec.whatwg.org/#body-mixin


### PR DESCRIPTION
This change adds support for the [Response.error()](https://fetch.spec.whatwg.org/#dom-response-error) and [Response.redirect()](https://fetch.spec.whatwg.org/#dom-response-redirect) static methods. Firefox and Chrome both support these methods.