### PR TITLE
Remove superfluous assignment

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -270,7 +270,6 @@
 
     this._initBody(bodyInit)
     this.type = 'default'
-    this.url = null
     this.status = options.status
     this.ok = this.status >= 200 && this.status < 300
     this.statusText = options.statusText


### PR DESCRIPTION
`this.url` is unconditionally assigned at the end of the constructor, so this assignment is unnecessary.