### PR TITLE
Fix incorrect assertion

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -372,7 +372,7 @@ suite('Response', function() {
     var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}});
     assert.equal(r.headers instanceof Headers, true);
     return r.json().then(function(json){
-      assert(json.foo, 'bar');
+      assert.equal(json.foo, 'bar');
       return json;
     })
   })


### PR DESCRIPTION
`assert()` checks for a truthy first parameter, and uses the second as the error message.