### PR TITLE
Reject the Promise returned by fetch() when Request ctor throws

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -285,14 +285,14 @@
   self.Response = Response;
 
   self.fetch = function(input, init) {
-    var request
-    if (Request.prototype.isPrototypeOf(input) && !init) {
-      request = input
-    } else {
-      request = new Request(input, init)
-    }
-
     return new Promise(function(resolve, reject) {
+      var request
+      if (Request.prototype.isPrototypeOf(input) && !init) {
+        request = input
+      } else {
+        request = new Request(input, init)
+      }
+
       var xhr = new XMLHttpRequest()
 
       function responseURL() {

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,14 @@ test.skip('rejects promise for network error', function() {
   })
 })
 
+test('rejects when Request constructor throws', function() {
+  return fetch('/request', { method: 'GET', body: 'invalid' }).then(function() {
+    assert(false, 'Invalid Request init was accepted')
+  }).catch(function(error) {
+    assert(error instanceof TypeError, 'Rejected with Error')
+  })
+})
+
 // https://fetch.spec.whatwg.org/#headers-class
 suite('Headers', function() {
   test('constructor copies headers', function() {
@@ -601,8 +609,7 @@ suite('Methods', function() {
     })
   })
 
-  // TODO: Waiting to verify behavior
-  test.skip('GET with body throws TypeError', function() {
+  test('GET with body throws TypeError', function() {
     assert.throw(function() {
       new Request('', {
         method: 'get',
@@ -611,7 +618,7 @@ suite('Methods', function() {
     }, TypeError)
   })
 
-  test.skip('HEAD with body throws TypeError', function() {
+  test('HEAD with body throws TypeError', function() {
     assert.throw(function() {
       new Request('', {
         method: 'head',


### PR DESCRIPTION
This solves part of what #132 does, but that PR seems abandoned.

https://fetch.spec.whatwg.org/#dom-global-fetch step 2 states that exceptions thrown by the Request constructor should cause fetch() to reject with the error. Exceptions thrown synchronously in the Promise callback will cause a rejection, so I've simply moved the Request ctor call into the Promise callback.

Manually verified that tests pass with native fetch implementations in Chrome and Firefox.