### PR TITLE
Expand URL in `Reponse.redirect()`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -292,6 +292,10 @@
       throw new RangeError('Invalid status code')
     }
 
+    var link = document.createElement('a')
+    link.href = url
+    url = link.href.toString()
+
     return new Response(null, {status: status, headers: {location: url}})
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -395,9 +395,10 @@ suite('Response', function() {
 
   test('redirect creates redirect Response', function() {
     var r = Response.redirect('/hello', 301)
+    var expectedUrl = location.protocol + '//' + location.host + '/hello'
     assert(r instanceof Response);
     assert.equal(r.status, 301)
-    assert.equal(r.headers.get('Location', '/hello'), '/hello')
+    assert.deepEqual(r.headers.getAll('Location'), [expectedUrl])
   })
 })
 


### PR DESCRIPTION
Native Chrome and Firefox implementations seem to expand the URL to include scheme, host, and port.

https://travis-ci.org/github/fetch/jobs/84727155

References #212 /cc @bryanrsmith

@dgraham: I didn't notice the Sauce failure because they're intermittently failing more often than actually running :/ Only after merging above PR to master did the Chrome test actually run and reveal a bug.
