### PR TITLE
Use absolute URL in Response.redirect test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -394,10 +394,10 @@ suite('Response', function() {
   })
 
   test('redirect creates redirect Response', function() {
-    var r = Response.redirect('/hello', 301)
+    var r = Response.redirect('https://fetch.spec.whatwg.org/', 301)
     assert(r instanceof Response);
     assert.equal(r.status, 301)
-    assert.equal(r.headers.get('Location', '/hello'), '/hello')
+    assert.equal(r.headers.get('Location'), 'https://fetch.spec.whatwg.org/')
   })
 })
 


### PR DESCRIPTION
This lets the `Response.redirect` test verify behavior of the method without being affected by the URL resolution issue (See #218), which is also an issue elsewhere.