### PR TITLE
Allow making a POST request with an ArrayBuffer body

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -116,7 +116,8 @@
         return false
       }
     })(),
-    formData: 'FormData' in self
+    formData: 'FormData' in self,
+    arrayBuffer: 'ArrayBuffer' in self
   }
 
   function Body() {
@@ -133,6 +134,9 @@
         this._bodyFormData = body
       } else if (!body) {
         this._bodyText = ''
+      } else if (support.arrayBuffer && ArrayBuffer.prototype.isPrototypeOf(body)) {
+        // Only support ArrayBuffers for POST method.
+        // Receiving ArrayBuffers happens via Blobs, instead.
       } else {
         throw new Error('unsupported BodyInit type')
       }

--- a/test/test.js
+++ b/test/test.js
@@ -205,6 +205,27 @@ suite('Request', function() {
     })
   })
 
+  ;(ArrayBuffer in self ? test : test.skip)('sends ArrayBuffer body', function() {
+    var text = 'name=Hubot'
+
+    var buf = new ArrayBuffer(text.length)
+    var view = new Uint8Array(buf)
+
+    for(var i = 0; i < text.length; i++) {
+      view[i] = text.charCodeAt(i)
+    }
+
+    return fetch('/request', {
+      method: 'post',
+      body: buf
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'POST')
+      assert.equal(request.data, 'name=Hubot')
+    })
+  })
+
   test('construct with url', function() {
     var request = new Request('https://fetch.spec.whatwg.org/')
     assert.equal(request.url, 'https://fetch.spec.whatwg.org/')


### PR DESCRIPTION
This enables POSTing with an ArrayBuffer body, but doesn't change the existing support for receiving ArrayBuffer responses (via blob)