### PR TITLE
Add PATCH to normalized method names

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -197,7 +197,7 @@
   }
 
   // HTTP methods whose capitalization should be normalized
-  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH']
 
   function normalizeMethod(method) {
     var upcased = method.toUpperCase()


### PR DESCRIPTION
Discovered in https://github.com/facebook/react-native/issues/4594, `PATCH` is not included in the normalized method names. This lead to some problems with the lowercased `patch` being forwarded onto the OkHTTP library in React Native and throwing an error as it was not interpreted properly.

This adds consistency to the method name normalizing process by including all the supported/common method types.