### PR TITLE
Make fetch add a `Content-Type` header based on the type of the body.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -307,6 +307,36 @@ suite('Request', function() {
     })
   })
 
+  test('construct with string body sets Content-Type header', function() {
+    var req = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      body: 'I work out'
+    })
+
+    assert.equal(req.headers.get('content-type'), 'text/plain;charset=UTF-8')
+  })
+
+  test('construct with Blob body and type sets Content-Type header', function() {
+    var req = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      body: new Blob(['test'], { type: 'text/plain' }),
+    })
+
+    assert.equal(req.headers.get('content-type'), 'text/plain')
+  })
+
+  test('construct with body and explicit header uses header', function() {
+    var req = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      body: 'I work out'
+    })
+
+    assert.equal(req.headers.get('content-type'), 'text/plain')
+  })
+
   test('clone request', function() {
     var req = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',
@@ -478,6 +508,26 @@ suite('Response', function() {
     assert(r instanceof Response);
     assert.equal(r.status, 301)
     assert.equal(r.headers.get('Location'), 'https://fetch.spec.whatwg.org/')
+  })
+
+  test('construct with string body sets Content-Type header', function() {
+    var r = new Response('I work out')
+    assert.equal(r.headers.get('content-type'), 'text/plain;charset=UTF-8')
+  })
+
+  test('construct with Blob body and type sets Content-Type header', function() {
+    var r = new Response(new Blob(['test'], { type: 'text/plain' }))
+    assert.equal(r.headers.get('content-type'), 'text/plain')
+  })
+
+  test('construct with body and explicit header uses header', function() {
+    var r = new Response('I work out', {
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+    })
+
+    assert.equal(r.headers.get('content-type'), 'text/plain')
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -316,7 +316,7 @@ suite('Request', function() {
     assert.equal(req.headers.get('content-type'), 'text/plain;charset=UTF-8')
   })
 
-  test('construct with Blob body and type sets Content-Type header', function() {
+  ;(Request.prototype.blob ? test : test.skip)('construct with Blob body and type sets Content-Type header', function() {
     var req = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',
       body: new Blob(['test'], { type: 'text/plain' }),
@@ -515,7 +515,7 @@ suite('Response', function() {
     assert.equal(r.headers.get('content-type'), 'text/plain;charset=UTF-8')
   })
 
-  test('construct with Blob body and type sets Content-Type header', function() {
+  ;(Response.prototype.blob ? test : test.skip)('construct with Blob body and type sets Content-Type header', function() {
     var r = new Response(new Blob(['test'], { type: 'text/plain' }))
     assert.equal(r.headers.get('content-type'), 'text/plain')
   })


### PR DESCRIPTION
Summary: The process of extracting a body from a passed in body object
(described here: https://fetch.spec.whatwg.org/#concept-bodyinit-extract)
creates both a byte stream and a corresponding `Content-Type` value. These two
values are used in the constructor of `Request` and `Response` objects to
initialize the body and to set an initial `Content-Type` header.

This change makes `Body._initBody()` return the `Content-Type` value
corresponding to the type of the object passed in, and to set that header in
the corresponding `Request` and `Response` objects that are being constructed.

There's a little bit of a dance I need to do in Request to keep track of where
the body is coming from, because we're only supposed to be setting the
`Content-Type` header if we're getting the body from the options passed in, not
if we're copying it from another `Request`. (This was caught by one of the
tests. Yay tests!)

I added some corresponding tests to make sure this works.

Test Plan:
I'm a little bit confused about how to run the tests normally, but this is what
I did:

 - Run `make lint`, see that everything passes
 - Start up the test server by running `node script/server 3900 &`
 - Visit http://localhost:3900/test/test.html and
   http://localhost:3900/test/test-worker.html in Chrome and see that all of
   the tests pass.

From what I can tell, running the tests in Chrome just used the native fetch
objects, so to test the polyfill I added `window.fetch = null` in
test/test.html before it includes '../fetch.js', and added `self.fetch = null`
in test/worker.js before it imports '../fetch.js'. Then:

 - Visit http://localhost:3900/test/test.html and
   http://localhost:3900/test/test-worker.html in Chrome and see that all of
   the tests pass.

Reviewers: @jeresig