### PR TITLE
Use uppercase methods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ fetch('/users.json').then(function(response) {
 var form = document.querySelector('form')
 
 fetch('/users', {
-  method: 'post',
+  method: 'POST',
   body: new FormData(form)
 })
 ```
@@ -86,7 +86,7 @@ fetch('/users', {
 
 ```javascript
 fetch('/users', {
-  method: 'post',
+  method: 'POST',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json'
@@ -108,7 +108,7 @@ data.append('file', input.files[0])
 data.append('user', 'hubot')
 
 fetch('/avatars', {
-  method: 'post',
+  method: 'POST',
   body: data
 })
 ```


### PR DESCRIPTION
HTTP methods are case-sensitive. The examples in the README currently
lead developers to think that this API normalizes all of the method
names to uppercase, leading to issues like #37 and #254.

Setting the right precedent in the README will prevent developers
from making mistake of trying to use method: 'patch' (or any
other verb that isn't normalized for backwards compatibility).