### PR TITLE
Use response.ok in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ status, define a custom response handler:
 
 ```javascript
 function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
+  if (response.ok) {
     return response
   } else {
     var error = new Error(response.statusText)


### PR DESCRIPTION
Use the `ok` property instead of explicitly checking for status code. A lot of people seem to copy paste this example, which means that they miss out on the useful `ok` property.

See https://developer.mozilla.org/en-US/docs/Web/API/Response/ok