### PR TITLE
Guard against `xhr.getAllResponseHeaders()` being `null`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -267,7 +267,7 @@
 
   function headers(xhr) {
     var head = new Headers()
-    var pairs = xhr.getAllResponseHeaders().trim().split('\n')
+    var pairs = (xhr.getAllResponseHeaders() || '').trim().split('\n')
     pairs.forEach(function(header) {
       var split = header.trim().split(':')
       var key = split.shift().trim()


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#getAllResponseHeaders():

> Returns all the response headers, separated by CRLF, as a string, or null if no response has been received.

I discovered this on Android, once when `xhr.getAllResponseHeaders()` evaluated to `null`.