### PR TITLE
Add Headers iterators

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -88,6 +88,17 @@
     }
   }
 
+  Headers.prototype.values = function() {
+    var items = []
+    this.forEach(function(value) { items.push(value) })
+    return {
+      next: function() {
+        var value = items.shift()
+        return {done: value === undefined, value: value}
+      }
+    }
+  }
+
   function consumed(body) {
     if (body.bodyUsed) {
       return Promise.reject(new TypeError('Already read'))

--- a/fetch.js
+++ b/fetch.js
@@ -99,6 +99,17 @@
     }
   }
 
+  Headers.prototype.entries = function() {
+    var items = []
+    this.forEach(function(value, name) { items.push([name, value]) })
+    return {
+      next: function() {
+        var value = items.shift()
+        return {done: value === undefined, value: value}
+      }
+    }
+  }
+
   function consumed(body) {
     if (body.bodyUsed) {
       return Promise.reject(new TypeError('Already read'))

--- a/fetch.js
+++ b/fetch.js
@@ -110,7 +110,7 @@
   var support = {
     blob: 'FileReader' in self && 'Blob' in self && (function() {
       try {
-        new Blob();
+        new Blob()
         return true
       } catch(e) {
         return false
@@ -320,9 +320,9 @@
     return new Response(null, {status: status, headers: {location: url}})
   }
 
-  self.Headers = Headers;
-  self.Request = Request;
-  self.Response = Response;
+  self.Headers = Headers
+  self.Request = Request
+  self.Response = Response
 
   self.fetch = function(input, init) {
     return new Promise(function(resolve, reject) {
@@ -345,7 +345,7 @@
           return xhr.getResponseHeader('X-Request-URL')
         }
 
-        return;
+        return
       }
 
       xhr.onload = function() {
@@ -355,7 +355,7 @@
           headers: headers(xhr),
           url: responseURL()
         }
-        var body = 'response' in xhr ? xhr.response : xhr.responseText;
+        var body = 'response' in xhr ? xhr.response : xhr.responseText
         resolve(new Response(body, options))
       }
 

--- a/fetch.js
+++ b/fetch.js
@@ -77,6 +77,17 @@
     }, this)
   }
 
+  Headers.prototype.keys = function() {
+    var items = []
+    this.forEach(function(value, name) { items.push(name) })
+    return {
+      next: function() {
+        var value = items.shift()
+        return {done: value === undefined, value: value}
+      }
+    }
+  }
+
   function consumed(body) {
     if (body.bodyUsed) {
       return Promise.reject(new TypeError('Already read'))

--- a/test/test.js
+++ b/test/test.js
@@ -232,6 +232,18 @@ suite('Headers', function() {
     assert.deepEqual({done: false, value: 'content-type'}, iterator.next())
     assert.deepEqual({done: true, value: undefined}, iterator.next())
   })
+  test('is iterable with values', function() {
+    var headers = new Headers()
+    headers.append('Accept', 'application/json')
+    headers.append('Accept', 'text/plain')
+    headers.append('Content-Type', 'text/html')
+
+    var iterator = headers.values()
+    assert.deepEqual({done: false, value: 'application/json'}, iterator.next())
+    assert.deepEqual({done: false, value: 'text/plain'}, iterator.next())
+    assert.deepEqual({done: false, value: 'text/html'}, iterator.next())
+    assert.deepEqual({done: true, value: undefined}, iterator.next())
+  })
  })
 
 // https://fetch.spec.whatwg.org/#request-class

--- a/test/test.js
+++ b/test/test.js
@@ -244,6 +244,18 @@ suite('Headers', function() {
     assert.deepEqual({done: false, value: 'text/html'}, iterator.next())
     assert.deepEqual({done: true, value: undefined}, iterator.next())
   })
+  test('is iterable with entries', function() {
+    var headers = new Headers()
+    headers.append('Accept', 'application/json')
+    headers.append('Accept', 'text/plain')
+    headers.append('Content-Type', 'text/html')
+
+    var iterator = headers.entries()
+    assert.deepEqual({done: false, value: ['accept', 'application/json']}, iterator.next())
+    assert.deepEqual({done: false, value: ['accept', 'text/plain']}, iterator.next())
+    assert.deepEqual({done: false, value: ['content-type', 'text/html']}, iterator.next())
+    assert.deepEqual({done: true, value: undefined}, iterator.next())
+  })
  })
 
 // https://fetch.spec.whatwg.org/#request-class

--- a/test/test.js
+++ b/test/test.js
@@ -220,6 +220,18 @@ suite('Headers', function() {
       assert.equal(this, thisArg)
     }, thisArg)
   })
+  test('is iterable with keys', function() {
+    var headers = new Headers()
+    headers.append('Accept', 'application/json')
+    headers.append('Accept', 'text/plain')
+    headers.append('Content-Type', 'text/html')
+
+    var iterator = headers.keys()
+    assert.deepEqual({done: false, value: 'accept'}, iterator.next())
+    assert.deepEqual({done: false, value: 'accept'}, iterator.next())
+    assert.deepEqual({done: false, value: 'content-type'}, iterator.next())
+    assert.deepEqual({done: true, value: undefined}, iterator.next())
+  })
  })
 
 // https://fetch.spec.whatwg.org/#request-class

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,7 @@ suite('Headers', function() {
   test('converts field value to string on set and get', function() {
     var headers = new Headers()
     headers.set('Content-Type', 1)
-    headers.set('X-CSRF-Token', undefined);
+    headers.set('X-CSRF-Token', undefined)
     assert.equal(headers.get('Content-Type'), '1')
     assert.equal(headers.get('X-CSRF-Token'), 'undefined')
   })
@@ -193,8 +193,8 @@ suite('Headers', function() {
     assert.throws(function() { new Headers({'<Accept>': ['application/json']}) }, TypeError)
     assert.throws(function() { new Headers({'Accept:': ['application/json']}) }, TypeError)
     assert.throws(function() {
-      var headers = new Headers();
-      headers.set({field: 'value'}, 'application/json');
+      var headers = new Headers()
+      headers.set({field: 'value'}, 'application/json')
     }, TypeError)
   })
   featureDependent(test, !nativeFirefox, 'is iterable with forEach', function() {
@@ -527,11 +527,11 @@ suite('Response', function() {
   })
 
   test('creates Headers object from raw headers', function() {
-    var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}});
-    assert.equal(r.headers instanceof Headers, true);
+    var r = new Response('{"foo":"bar"}', {headers: {'content-type': 'application/json'}})
+    assert.equal(r.headers instanceof Headers, true)
     return r.json().then(function(json){
-      assert.equal(json.foo, 'bar');
-      return json;
+      assert.equal(json.foo, 'bar')
+      return json
     })
   })
 
@@ -574,7 +574,7 @@ suite('Response', function() {
 
   test('redirect creates redirect Response', function() {
     var r = Response.redirect('https://fetch.spec.whatwg.org/', 301)
-    assert(r instanceof Response);
+    assert(r instanceof Response)
     assert.equal(r.status, 301)
     assert.equal(r.headers.get('Location'), 'https://fetch.spec.whatwg.org/')
   })
@@ -949,7 +949,7 @@ suite('Atomic HTTP redirect handling', function() {
 // https://fetch.spec.whatwg.org/#concept-request-credentials-mode
 suite('credentials mode', function() {
   setup(function() {
-    return fetch('/cookie?name=foo&value=reset', {credentials: 'same-origin'});
+    return fetch('/cookie?name=foo&value=reset', {credentials: 'same-origin'})
   })
 
   featureDependent(suite, exerciseMode === 'native', 'omit', function() {
@@ -960,7 +960,7 @@ suite('credentials mode', function() {
 
     test('does not accept cookies with implicit omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar').then(function() {
-        return fetch('/cookie?name=foo', {credentials: 'same-origin'});
+        return fetch('/cookie?name=foo', {credentials: 'same-origin'})
       }).then(function(response) {
         return response.text()
       }).then(function(data) {
@@ -970,7 +970,7 @@ suite('credentials mode', function() {
 
     test('does not accept cookies with omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar', {credentials: 'omit'}).then(function() {
-        return fetch('/cookie?name=foo', {credentials: 'same-origin'});
+        return fetch('/cookie?name=foo', {credentials: 'same-origin'})
       }).then(function(response) {
         return response.text()
       }).then(function(data) {
@@ -980,7 +980,7 @@ suite('credentials mode', function() {
 
     test('does not send cookies with implicit omit credentials', function() {
       return fetch('/cookie?name=foo&value=bar', {credentials: 'same-origin'}).then(function() {
-        return fetch('/cookie?name=foo');
+        return fetch('/cookie?name=foo')
       }).then(function(response) {
         return response.text()
       }).then(function(data) {


### PR DESCRIPTION
Adds `entries`, `keys`, and `values` iterator functions to `Headers`. Each iterator, and `Headers` itself, is also `iterable` if the browser supports `Symbol.iterator`. The [medikoo/es6-symbol](https://github.com/medikoo/es6-symbol) polyfill may be used in browsers without `Symbol`.

Background:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators
- https://fetch.spec.whatwg.org/#headers
- http://heycam.github.io/webidl/#idl-iterable
- http://heycam.github.io/webidl/#es-iterable

Closes #292.

/cc @lukeapage @dkfiresky