### PR TITLE
README examples with uppercased method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ fetch('/users.json').then(function(response) {
 var form = document.querySelector('form')
 
 fetch('/users', {
-  method: 'post',
+  method: 'POST',
   body: new FormData(form)
 })
 ```
@@ -86,7 +86,7 @@ fetch('/users', {
 
 ```javascript
 fetch('/users', {
-  method: 'post',
+  method: 'POST',
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json'
@@ -108,7 +108,7 @@ data.append('file', input.files[0])
 data.append('user', 'hubot')
 
 fetch('/avatars', {
-  method: 'post',
+  method: 'POST',
   body: data
 })
 ```


### PR DESCRIPTION
This addresses the confusion brought up in #243. 

TL;DR - [method types are normalized to be uppercased](https://github.com/ajwhite/fetch/blob/c5200ebe021d1ed0222d6005641ecac35e29e589/fetch.js#L199-L205), however [`PATCH` is not included in the normalization rule of the `fetch` specification](https://fetch.spec.whatwg.org/#concept-method-normalize). To avoid confusion, the examples now show method names in uppercase.

Hopefully this can help train the developer to use uppercase names and not fall into the `patch` trap.

/cc @mislav and @dgraham 