### PR TITLE
Add support for URLSearchParams POST body

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
   "browser": true,
   "worker": true,
   "globals": {
-    "JSON": false
+    "JSON": false,
+    "URLSearchParams": false
   }
 }

--- a/fetch.js
+++ b/fetch.js
@@ -6,6 +6,7 @@
   }
 
   var support = {
+    searchParams: 'URLSearchParams' in self,
     iterable: 'Symbol' in self && 'iterator' in Symbol,
     blob: 'FileReader' in self && 'Blob' in self && (function() {
       try {
@@ -193,6 +194,8 @@
         this._bodyBlob = body
       } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
         this._bodyFormData = body
+      } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+        this._bodyText = body.toString()
       } else if (!body) {
         this._bodyText = ''
       } else if (support.arrayBuffer && ArrayBuffer.prototype.isPrototypeOf(body)) {
@@ -207,6 +210,8 @@
           this.headers.set('content-type', 'text/plain;charset=UTF-8')
         } else if (this._bodyBlob && this._bodyBlob.type) {
           this.headers.set('content-type', this._bodyBlob.type)
+        } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+          this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,7 @@
   "version": "0.11.0",
   "main": "fetch.js",
   "repository": "github/fetch",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/github/fetch/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "bower": "1.3.8",
     "chai": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "bower": "1.3.8",
     "chai": "1.10.0",
     "jshint": "2.8.0",
-    "mocha-phantomjs": "3.5.2",
     "mocha": "2.1.0",
-    "phantomjs": "1.9.19"
+    "mocha-phantomjs": "3.5.2",
+    "phantomjs": "1.9.19",
+    "url-search-params": "0.5.0"
   },
-  "files" : [
+  "files": [
     "LICENSE",
     "fetch.js"
   ]

--- a/test/test-worker.html
+++ b/test/test-worker.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <div id="mocha"></div>
+  <script src="/node_modules/url-search-params/build/url-search-params.js"></script>
   <script src="/node_modules/mocha/mocha.js"></script>
 
   <script>

--- a/test/test.html
+++ b/test/test.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <div id="mocha"></div>
+  <script src="/node_modules/url-search-params/build/url-search-params.js"></script>
   <script src="/node_modules/chai/chai.js"></script>
   <script src="/node_modules/mocha/mocha.js"></script>
   <script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var support = {
+  searchParams: 'URLSearchParams' in self,
   blob: 'FileReader' in self && 'Blob' in self && (function() {
     try {
       new Blob()
@@ -311,6 +312,18 @@ suite('Request', function() {
     })
   })
 
+  featureDependent(test, support.searchParams, 'sends URLSearchParams body', function() {
+    return fetch('/request', {
+      method: 'post',
+      body: new URLSearchParams('a=1&b=2')
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'POST')
+      assert.equal(request.data, 'a=1&b=2')
+    })
+  })
+
   test('construct with url', function() {
     var request = new Request('https://fetch.spec.whatwg.org/')
     assert.equal(request.url, 'https://fetch.spec.whatwg.org/')
@@ -437,6 +450,25 @@ suite('Request', function() {
       method: 'post',
       headers: { 'Content-Type': 'image/png' },
       body: new Blob(['test'], { type: 'text/plain' })
+    })
+
+    assert.equal(req.headers.get('content-type'), 'image/png')
+  })
+
+  featureDependent(test, support.searchParams, 'construct with URLSearchParams body sets Content-Type header', function() {
+    var req = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      body: new URLSearchParams('a=1&b=2')
+    })
+
+    assert.equal(req.headers.get('content-type'), 'application/x-www-form-urlencoded;charset=UTF-8')
+  })
+
+  featureDependent(test, support.searchParams, 'construct with URLSearchParams body and explicit Content-Type header', function() {
+    var req = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      headers: { 'Content-Type': 'image/png' },
+      body: new URLSearchParams('a=1&b=2')
     })
 
     assert.equal(req.headers.get('content-type'), 'image/png')


### PR DESCRIPTION
Allows a [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) object to be serialized as a request body with a `Content-Type: application/x-www-form-urlencoded`  header.

```js
var params = new URLSearchParams()
params.append('user', 'hubot')
fetch('/test', {method: 'post', body: params})
```

Related:

- https://fetch.spec.whatwg.org/#body-mixin
- https://url.spec.whatwg.org/#urlsearchparams
- https://developers.google.com/web/updates/2016/01/urlsearchparams
- https://github.com/WebReflection/url-search-params

Closes #296.

/cc @mislav @btd 