### PR TITLE
Reject promise on request timeout

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -429,6 +429,10 @@
         reject(new TypeError('Network request failed'))
       }
 
+      xhr.ontimeout = function() {
+        reject(new TypeError('Network request failed'))
+      }
+
       xhr.open(request.method, request.url, true)
 
       if (request.credentials === 'include') {


### PR DESCRIPTION
Firefox and Chrome trigger the request's `onerror` handler when a timeout occurs. Safari triggers the `ontimeout` handler.

This can be observed by making a request to an unroutable address:

```js
var xhr = new XMLHttpRequest()
xhr.onload = console.log.bind(console, 'loaded')
xhr.onerror = console.log.bind(console, 'errored')
xhr.ontimeout = console.log.bind(console, 'timeout')
xhr.open('GET', 'http://10.255.255.1')
xhr.send()
```

Fixes #294.

@mislav @fabioberger