### PR TITLE
Switch to `mocha-phantomjs-core` and system PhantomJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "chai": "1.10.0",
     "jshint": "2.8.0",
     "mocha": "2.1.0",
-    "mocha-phantomjs": "3.5.2",
-    "phantomjs": "1.9.19",
+    "mocha-phantomjs-core": "2.0.1",
     "url-search-params": "0.5.0"
   },
   "files": [

--- a/script/phantomjs
+++ b/script/phantomjs
@@ -14,12 +14,16 @@ trap "kill $server_pid" INT EXIT
 
 STATUS=0
 
+reporter=dot
+[ -z "$CI" ] || reporter=spec
+
 run() {
-  node ./node_modules/.bin/mocha-phantomjs \
-    -s localToRemoteUrlAccessEnabled=true \
-    -s webSecurityEnabled=false \
-    "$@" || STATUS=$?
+  phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
+    "$1" $reporter "{\"useColors\":true, \"hooks\":\"$PWD/test/mocha-phantomjs-hooks.js\"}" \
+    || STATUS=$?
 }
+
+[ -z "$CI" ] || echo "phantomjs $(phantomjs -v)"
 
 run "http://localhost:$port/"
 run "http://localhost:$port/test/test-worker.html"

--- a/test/mocha-phantomjs-hooks.js
+++ b/test/mocha-phantomjs-hooks.js
@@ -1,0 +1,9 @@
+/* globals exports */
+exports.beforeStart = function(context) {
+  var originalResourceError = context.page.onResourceError
+  context.page.onResourceError = function(resErr) {
+    if (!/\/boom$/.test(resErr.url)) {
+      originalResourceError(resErr)
+    }
+  }
+}

--- a/test/test-worker.html
+++ b/test/test-worker.html
@@ -11,7 +11,12 @@
   <script src="/node_modules/mocha/mocha.js"></script>
 
   <script>
+    if (self.initMochaPhantomJS) {
+      self.initMochaPhantomJS()
+    }
+
     mocha.setup('tdd')
+    mocha.suite.suites.unshift(Mocha.Suite.create(mocha.suite, "worker"))
 
     var worker = new Worker('/test/worker.js')
 
@@ -31,11 +36,7 @@
           })
           break
         case 'end':
-          if (self.mochaPhantomJS) {
-            mochaPhantomJS.run()
-          } else {
-            mocha.run()
-          }
+          mocha.run()
           break
       }
     })

--- a/test/test.html
+++ b/test/test.html
@@ -11,6 +11,10 @@
   <script src="/node_modules/chai/chai.js"></script>
   <script src="/node_modules/mocha/mocha.js"></script>
   <script>
+    if (self.initMochaPhantomJS) {
+      self.initMochaPhantomJS()
+    }
+
     if (self.mocha && mocha.setup) {
       mocha.setup('tdd')
       self.assert = chai.assert
@@ -24,31 +28,27 @@
   <script src="/fetch.js"></script>
 
   <script>
-    if (self.mochaPhantomJS) {
-      mochaPhantomJS.run();
-    } else {
-      var runner = mocha.run();
+    var runner = mocha.run();
 
-      var failedTests = [];
+    var failedTests = [];
 
-      runner.on('end', function(){
-        window.mochaResults = runner.stats;
-        window.mochaResults.reports = failedTests;
-      });
+    runner.on('end', function(){
+      window.mochaResults = runner.stats;
+      window.mochaResults.reports = failedTests;
+    });
 
-      runner.on('fail', function(test, err){
-        function flattenTitles(test){
-          var titles = [];
-          while (test.parent.title){
-            titles.push(test.parent.title);
-            test = test.parent;
-          }
-          return titles.reverse();
-        };
+    runner.on('fail', function(test, err){
+      function flattenTitles(test){
+        var titles = [];
+        while (test.parent.title){
+          titles.push(test.parent.title);
+          test = test.parent;
+        }
+        return titles.reverse();
+      };
 
-        failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
-      });
-    }
+      failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This switches to the more lightweight mocha-phantomjs-core project that allows us to use system PhantomJS, which should be the later 2.x series rather than 1.9.

/cc @dgraham