### PR TITLE
Update Webpack section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ $ npm install whatwg-fetch --save
 
 For a node.js implementation, try [node-fetch](https://github.com/bitinn/node-fetch).
 
-For use with webpack, refer to [Using WebPack with shims and polyfills](http://mts.io/2015/04/08/webpack-shims-polyfills/).
+For use with webpack, add this package in the `entry` configuration option before your application entry point:
+
+```javascript
+entry: ['whatwg-fetch', ...]
+```
 
 For babel and es2015+, make sure to import the file:
 


### PR DESCRIPTION
The currently linked solution for Webpack usage is incorrect as it does not define `fetch` as a global and as a result will fail when an application uses external modules which expect `fetch` to be available, as those will generally not be processed by Webpack's `ProvidePlugin`.

Including `fetch` in the `entry` configuration of Webpack is the correct way to polyfill and fixes this issue. This is consistent with how other polyfills are used e.g. [babel-polyfill](https://babeljs.io/docs/usage/polyfill/), and does not require any special loader.