### PR TITLE
Fixes #308. Avoid consuming same body when cloning

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -299,9 +299,7 @@
   }
 
   Request.prototype.clone = function() {
-    var newRequest = new Request(this, { body: 'clone' })
-    newRequest._initBody(this._bodyInit)
-    return newRequest
+    return new Request(this, { body: this._bodyInit })
   }
 
   function decode(body) {

--- a/fetch.js
+++ b/fetch.js
@@ -167,6 +167,11 @@
 
     this._initBody = function(body) {
       this._bodyInit = body
+
+      delete this._bodyText
+      delete this._bodyBlob
+      delete this._bodyFormData
+
       if (typeof body === 'string') {
         this._bodyText = body
       } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
@@ -294,7 +299,9 @@
   }
 
   Request.prototype.clone = function() {
-    return new Request(this)
+    var newRequest = new Request(this, { body: 'clone' })
+    newRequest._initBody(this._bodyInit)
+    return newRequest
   }
 
   function decode(body) {

--- a/fetch.js
+++ b/fetch.js
@@ -168,10 +168,6 @@
     this._initBody = function(body) {
       this._bodyInit = body
 
-      delete this._bodyText
-      delete this._bodyBlob
-      delete this._bodyFormData
-
       if (typeof body === 'string') {
         this._bodyText = body
       } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {

--- a/test/test.js
+++ b/test/test.js
@@ -491,6 +491,19 @@ suite('Request', function() {
     })
   })
 
+  test('clone request bodies', function() {
+    var r1 = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      headers: {'content-type': 'text/plain'},
+      body: 'I work out'
+    })
+    var r2 = r1.clone()
+
+    return Promise.all([r1.text(), r2.text()]).then(function(texts){
+      return assert.equal(texts[0], texts[1], 'both requests succeed with equal texts')
+    })
+  })
+
   featureDependent(test, !nativeChrome, 'clone with used Request body', function() {
     var req = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',

--- a/test/test.js
+++ b/test/test.js
@@ -494,13 +494,12 @@ suite('Request', function() {
   test('clone request bodies', function() {
     var r1 = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',
-      headers: {'content-type': 'text/plain'},
       body: 'I work out'
     })
     var r2 = r1.clone()
 
     return Promise.all([r1.text(), r2.text()]).then(function(texts){
-      return assert.equal(texts[0], texts[1], 'both requests succeed with equal texts')
+      assert.equal(texts[0], texts[1], 'both requests succeed with equal texts')
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -503,6 +503,19 @@ suite('Request', function() {
     })
   })
 
+  featureDependent(test, support.blob, 'clone with body Blob and test independence', function() {
+    var r1 = new Request('https://fetch.spec.whatwg.org/', {
+      method: 'post',
+      body: new Blob(['I work out'])
+    })
+    var r2 = r1.clone()
+
+    return Promise.all([r1.blob().then(readBlobAsText), r2.blob().then(readBlobAsText)]).then(function(texts) {
+      assert.equal(texts[0], 'I work out', 'request original body blob read succeed')
+      assert.equal(texts[1], 'I work out', 'request clone body blob read succeed')
+    })
+  })
+
   featureDependent(test, !nativeChrome, 'clone with used Request body', function() {
     var req = new Request('https://fetch.spec.whatwg.org/', {
       method: 'post',


### PR DESCRIPTION
Body of Request must be cloned using a value to avoid consumption of
it. Once a new body is initialized, re-initialize the old value.
Includes a test that fails with the old code.
