### PR TITLE
Use response.ok in error-handling docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ status, define a custom response handler:
 
 ```javascript
 function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
+  if (response.ok) { // true if and only if response.status >= 200 && response.status < 300
     return response
   } else {
     var error = new Error(response.statusText)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ status, define a custom response handler:
 
 ```javascript
 function checkStatus(response) {
-  if (response.ok) { // true if and only if response.status >= 200 && response.status < 300
+  if (response.ok) {
+    // true if response.status >= 200 && response.status < 300
     return response
   } else {
     var error = new Error(response.statusText)


### PR DESCRIPTION
Checking the response status is in the 2xx range is equivalent to checking `.ok`.

https://github.com/github/fetch/blob/master/fetch.js#L334

This has the added benefit of documenting that API (`.ok` is a little vague), and making the example code a bit simpler (albeit less explicit).

PS - since this is just a small edit spanning two commits, I think it would be better to squash it in.