### PR TITLE
Better error handling with Saucelabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ clean:
 
 ifeq ($(shell uname -s),Darwin)
 sauce_connect/bin/sc:
-	wget https://saucelabs.com/downloads/sc-4.3.11-osx.zip
-	unzip sc-4.3.11-osx.zip
-	mv sc-4.3.11-osx sauce_connect
-	rm sc-4.3.11-osx.zip
+	wget https://saucelabs.com/downloads/sc-4.3.16-osx.zip
+	unzip sc-4.3.16-osx.zip
+	mv sc-4.3.16-osx sauce_connect
+	rm sc-4.3.16-osx.zip
 else
 sauce_connect/bin/sc:
 	mkdir -p sauce_connect
-	curl -fsSL http://saucelabs.com/downloads/sc-4.3.11-linux.tar.gz | tar xz -C sauce_connect --strip-components 1
+	curl -fsSL http://saucelabs.com/downloads/sc-4.3.16-linux.tar.gz | tar xz -C sauce_connect --strip-components 1
 endif
 
 .PHONY: build clean lint test saucelabs travis

--- a/script/saucelabs
+++ b/script/saucelabs
@@ -16,7 +16,16 @@ sauce_connect/bin/sc -u "$SAUCE_USERNAME" -k "$SAUCE_ACCESS_KEY" \
 sauce_pid=$!
 trap "kill $sauce_pid" INT EXIT
 
-while [ ! -f "$sauce_ready" ]; do sleep .01; done
+sauce_waited=0
+while [ ! -f "$sauce_ready" ]; do
+  if [ "$sauce_waited" -gt 60000 ]; then
+    echo "sauce_connect failed to start within 60 seconds" >&2
+    exit 1
+  fi
+  sleep .01
+  sauce_waited=$((sauce_waited + 10))
+done
+echo "sauce_connect started within $sauce_waited ms"
 rm -f "$sauce_ready"
 
 job="$(./script/saucelabs-api --raw "js-tests" <<JSON
@@ -31,10 +40,14 @@ job="$(./script/saucelabs-api --raw "js-tests" <<JSON
 JSON
 )"
 
-while true; do
+while sleep 5; do
   result=$(./script/saucelabs-api "js-tests/status" <<<"$job")
+  if grep -q '.status: test error' <<<"$result"; then
+    echo
+    echo "$result" >&2
+    exit 1
+  fi
   grep -q "^completed: true" <<<"$result" && break
-  sleep 1
   echo -n "."
 done
 
@@ -48,6 +61,6 @@ awk '
   /\.url:/ { print $(NF) }
   END {
     printf "%d passed, %d pending, %d failures\n", passes, pending, failures
-    if (failures > 0 || tests != passes + pending) exit 1
+    if (failures > 0 || tests != passes + pending || tests == 0) exit 1
   }
 ' <<<"$result"

--- a/script/saucelabs-api
+++ b/script/saucelabs-api
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 raw=""
 if [ "$1" = "--raw" ]; then
@@ -9,7 +10,7 @@ fi
 
 endpoint="$1"
 
-curl -fs -X POST "https://saucelabs.com/rest/v1/$SAUCE_USERNAME/${endpoint}" \
+curl -fsS -X POST "https://saucelabs.com/rest/v1/$SAUCE_USERNAME/${endpoint}" \
   -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" \
   -H "Content-Type: application/json" -d "@-" | \
 {


### PR DESCRIPTION
- Update sauce_connect
- Timeout handling for sauce_connect
- Have `saucelabs-api` show error message on HTTP errors
- Have `saucelabs-api` exit with nonzero on errors
- Exit with nonzero if Saucelabs reports that 0 tests have ran
- Abort Saucelabs API polling on "test error" (unsure what causes this)

This will hopefully give us more insight into Saucelabs failures during CI runs.