### PR TITLE
Clarifying the default `Set-Cookie` behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ fetch('/avatars', {
 
 ### Caveats
 
-The `fetch` specification differs from `jQuery.ajax()` in mainly two ways that
+The `fetch` specification differs from `jQuery.ajax()` in mainly three ways that
 bear keeping in mind:
 
 * The Promise returned from `fetch()` **won't reject on HTTP error status**

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ bear keeping in mind:
 * By default, `fetch` **won't send any cookies** to the server, resulting in
   unauthenticated requests if the site relies on maintaining a user session.
 
+* By default, the **browser will not store any cookies** set in `fetch()` responses.
+
 #### Handling HTTP error statuses
 
 To have `fetch` Promise reject on HTTP error statuses, i.e. on any non-2xx
@@ -191,6 +193,9 @@ fetch('https://example.com:1234/users', {
 ```
 
 #### Receiving cookies
+
+By default, the browser will ignore the `Set-Cookie` response header unless the
+`credentials` option is provided.
 
 Like with XMLHttpRequest, the `Set-Cookie` response header returned from the
 server is a [forbidden header name][] and therefore can't be programatically


### PR DESCRIPTION
I'm trying to make it clear that the `credentials` option affects setting cookies.

Perhaps this will prevent future tickets like https://github.com/github/fetch/issues/386
