### PR TITLE
Safari 10 does not have a native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,4 +225,4 @@ Firefox < 32, Chrome < 37, Safari, or IE.
 - Internet Explorer 10+
 - Microsoft Edge
 
-Note: Chrome, Firefox, Microsft Edge, and Safari 10 contain native implementations of `window.fetch`, so this polyfill code does not run in those browsers.
+Note: Chrome, Firefox, and Microsoft Edge contain native implementations of `window.fetch`, so this polyfill code does not run in those browsers.


### PR DESCRIPTION
As it turns out, Safari 10 does not support `window.fetch`. This is easily confirmed at the JavaScript console and documented by [caniuse](http://caniuse.com/#feat=fetch). The polyfill code does run on Safari 10.