### PR TITLE
Fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ fetch('/users', {
 })
 ```
 
-This option makes `fetch` behave similar to XMLHttpRequest with regards to
+This option makes `fetch` behave similarly to XMLHttpRequest with regards to
 cookies. Otherwise, cookies won't get sent, resulting in these requests not
 preserving the authentication session.
 


### PR DESCRIPTION
"similar" -> "similarly"

The adjective similar is modifying behave instead of a noun or pronoun. 

> Use an adverb to modify a verb, adjective, or another adverb.