### PR TITLE
Improve the example with headers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ fetch('/users', {
 ```javascript
 fetch('/users', {
   method: 'POST',
-  headers: {
+  headers: new Headers({
     'Accept': 'application/json',
     'Content-Type': 'application/json'
-  },
+  }),
   body: JSON.stringify({
     name: 'Hubot',
     login: 'hubot',


### PR DESCRIPTION
I found some problems running the POST JSON example in my project. I use a modern Chrome version, so it uses a native `fetch` implementation. In this case, if I send the headers like the example, I'd use an object:

```javascript
var headers = {
  'Accept': 'application/json',
  'Content-Type': 'application/json'
}
```

However, this object is not valid for native `fetch` because it requires a `Headers` instance. I found this in [Using Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Headers) documentation from Mozilla. After update my code to use `Headers`, it works fine:

```javascript
var headers =  new Headers({
  'Accept': 'application/json',
  'Content-Type': 'application/json'
})
```

I checked your code and I saw that it's compatible with `Headers` object ([fetch.js#L61](https://github.com/github/fetch/blob/master/fetch.js#L61)).

Thanks! :)