### PR TITLE
Spec compatibility for Request/Response constructors and cloning

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -334,7 +334,7 @@
     this.status = options.status
     this.ok = this.status >= 200 && this.status < 300
     this.statusText = options.statusText
-    this.headers = options.headers instanceof Headers ? options.headers : new Headers(options.headers)
+    this.headers = new Headers(options.headers)
     this.url = options.url || ''
     this._initBody(bodyInit)
   }

--- a/fetch.js
+++ b/fetch.js
@@ -372,13 +372,7 @@
 
   self.fetch = function(input, init) {
     return new Promise(function(resolve, reject) {
-      var request
-      if (Request.prototype.isPrototypeOf(input) && !init) {
-        request = input
-      } else {
-        request = new Request(input, init)
-      }
-
+      var request = new Request(input, init)
       var xhr = new XMLHttpRequest()
 
       function responseURL() {

--- a/fetch.js
+++ b/fetch.js
@@ -274,7 +274,7 @@
       }
       this.method = input.method
       this.mode = input.mode
-      if (!body) {
+      if (!body && input._bodyInit != null) {
         body = input._bodyInit
         input.bodyUsed = true
       }

--- a/fetch.js
+++ b/fetch.js
@@ -295,7 +295,7 @@
   }
 
   Request.prototype.clone = function() {
-    return new Request(this)
+    return new Request(this, { body: this._bodyInit })
   }
 
   function decode(body) {

--- a/fetch.js
+++ b/fetch.js
@@ -260,7 +260,10 @@
   function Request(input, options) {
     options = options || {}
     var body = options.body
-    if (Request.prototype.isPrototypeOf(input)) {
+
+    if (typeof input === 'string') {
+      this.url = input
+    } else {
       if (input.bodyUsed) {
         throw new TypeError('Already read')
       }
@@ -275,8 +278,6 @@
         body = input._bodyInit
         input.bodyUsed = true
       }
-    } else {
-      this.url = input
     }
 
     this.credentials = options.credentials || this.credentials || 'omit'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jshint": "2.8.0",
     "mocha": "2.1.0",
     "mocha-phantomjs-core": "2.0.1",
-    "url-search-params": "0.5.0"
+    "url-search-params": "0.6.1"
   },
   "files": [
     "LICENSE",

--- a/test/test.js
+++ b/test/test.js
@@ -840,6 +840,33 @@ suite('fetch method', function() {
       })
     })
 
+    test('reusing same Request multiple times', function() {
+      var request = new Request('/request', {
+        headers: {
+          'Accept': 'application/json',
+          'X-Test': '42'
+        }
+      })
+
+      var responses = []
+
+      return fetch(request).then(function(response) {
+        responses.push(response)
+        return fetch(request)
+      }).then(function(response) {
+        responses.push(response)
+        return fetch(request)
+      }).then(function(response) {
+        responses.push(response)
+        return Promise.all(responses.map(function(r) { return r.json() }))
+      }).then(function(jsons) {
+        jsons.forEach(function(json) {
+          assert.equal(json.headers['accept'], 'application/json')
+          assert.equal(json.headers['x-test'], '42')
+        })
+      })
+    })
+
     featureDependent(test, support.arrayBuffer, 'sends ArrayBuffer body', function() {
       return fetch('/request', {
         method: 'post',

--- a/test/test.js
+++ b/test/test.js
@@ -507,6 +507,14 @@ suite('Response', function() {
     })
   })
 
+  test('always creates a new Headers instance', function() {
+    var headers = new Headers({ 'x-hello': 'world' })
+    var res = new Response('', {headers: headers})
+
+    assert.equal(res.headers.get('x-hello'), 'world')
+    assert.notEqual(res.headers, headers)
+  })
+
   test('clone text response', function() {
     var res = new Response('{"foo":"bar"}', {
       headers: {'content-type': 'application/json'}

--- a/test/test.js
+++ b/test/test.js
@@ -508,14 +508,14 @@ suite('Request', function() {
   suite('BodyInit extract', function() {
     featureDependent(suite, support.blob, 'type Blob', function() {
       test('consume as blob', function() {
-        var request = new Request(null, {method: 'POST', body: new Blob(['hello'])})
+        var request = new Request('', {method: 'POST', body: new Blob(['hello'])})
         return request.blob().then(readBlobAsText).then(function(text) {
           assert.equal(text, 'hello')
         })
       })
 
       test('consume as text', function() {
-        var request = new Request(null, {method: 'POST', body: new Blob(['hello'])})
+        var request = new Request('', {method: 'POST', body: new Blob(['hello'])})
         return request.text().then(function(text) {
           assert.equal(text, 'hello')
         })
@@ -524,14 +524,14 @@ suite('Request', function() {
 
     suite('type USVString', function() {
       test('consume as text', function() {
-        var request = new Request(null, {method: 'POST', body: 'hello'})
+        var request = new Request('', {method: 'POST', body: 'hello'})
         return request.text().then(function(text) {
           assert.equal(text, 'hello')
         })
       })
 
       featureDependent(test, support.blob, 'consume as blob', function() {
-        var request = new Request(null, {method: 'POST', body: 'hello'})
+        var request = new Request('', {method: 'POST', body: 'hello'})
         return request.blob().then(readBlobAsText).then(function(text) {
           assert.equal(text, 'hello')
         })

--- a/test/test.js
+++ b/test/test.js
@@ -406,9 +406,10 @@ suite('Request', function() {
     assert.equal(clone.method, 'POST')
     assert.equal(clone.headers.get('content-type'), 'text/plain')
     assert.notEqual(clone.headers, req.headers)
+    assert.equal(req.bodyUsed, false)
 
-    return clone.text().then(function(body) {
-      assert.equal(body, 'I work out')
+    return Promise.all([clone.text(), req.clone().text()]).then(function(bodies) {
+      assert.deepEqual(bodies, ['I work out', 'I work out'])
     })
   })
 


### PR DESCRIPTION
Various loosely related fixes, most important being the ability to re-use the same GET Request instance for multiple `fetch()` invocations.

The huge diff in tests is due to tests reorg.

/cc @josh @dgraham