### PR TITLE
Support ArrayBufferView types as POST body

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,8 @@ sauce_connect/bin/sc:
 	curl -fsSL http://saucelabs.com/downloads/sc-4.3.16-linux.tar.gz | tar xz -C sauce_connect --strip-components 1
 endif
 
-.PHONY: build clean lint test saucelabs travis
+phantomjs/bin/phantomjs:
+	mkdir -p phantomjs
+	wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O- | tar xj -C phantomjs --strip-components 1
+
+.PHONY: build clean lint test

--- a/fetch.js
+++ b/fetch.js
@@ -33,6 +33,10 @@
       '[object Float64Array]'
     ]
 
+    var isDataView = function(obj) {
+      return obj && DataView.prototype.isPrototypeOf(obj)
+    }
+
     var isArrayBufferView = ArrayBuffer.isView || function(obj) {
       return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
     }
@@ -195,6 +199,9 @@
         this._bodyText = body.toString()
       } else if (!body) {
         this._bodyText = ''
+      } else if (support.arrayBuffer && isDataView(body)) {
+        // IE 10-11 can't handle a DataView body.
+        this._bodyInit = new Blob([body.buffer])
       } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
         // Only support ArrayBuffers for POST method.
         // Receiving ArrayBuffers happens via Blobs, instead.

--- a/fetch.js
+++ b/fetch.js
@@ -20,6 +20,24 @@
     arrayBuffer: 'ArrayBuffer' in self
   }
 
+  if (support.arrayBuffer) {
+    var viewClasses = [
+      '[object Int8Array]',
+      '[object Uint8Array]',
+      '[object Uint8ClampedArray]',
+      '[object Int16Array]',
+      '[object Uint16Array]',
+      '[object Int32Array]',
+      '[object Uint32Array]',
+      '[object Float32Array]',
+      '[object Float64Array]'
+    ]
+
+    var isArrayBufferView = ArrayBuffer.isView || function(obj) {
+      return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
+    }
+  }
+
   function normalizeName(name) {
     if (typeof name !== 'string') {
       name = String(name)
@@ -177,7 +195,7 @@
         this._bodyText = body.toString()
       } else if (!body) {
         this._bodyText = ''
-      } else if (support.arrayBuffer && ArrayBuffer.prototype.isPrototypeOf(body)) {
+      } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
         // Only support ArrayBuffers for POST method.
         // Receiving ArrayBuffers happens via Blobs, instead.
       } else {

--- a/fetch.js
+++ b/fetch.js
@@ -199,7 +199,7 @@
         this._bodyText = body.toString()
       } else if (!body) {
         this._bodyText = ''
-      } else if (support.arrayBuffer && isDataView(body)) {
+      } else if (support.arrayBuffer && support.blob && isDataView(body)) {
         // IE 10-11 can't handle a DataView body.
         this._bodyInit = new Blob([body.buffer])
       } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {

--- a/script/phantomjs
+++ b/script/phantomjs
@@ -17,6 +17,11 @@ STATUS=0
 reporter=dot
 [ -z "$CI" ] || reporter=spec
 
+if [ -n "$TRAVIS" ]; then
+  make phantomjs/bin/phantomjs
+  export PATH="$PWD/phantomjs/bin:$PATH"
+fi
+
 run() {
   phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
     "$1" $reporter "{\"useColors\":true, \"hooks\":\"$PWD/test/mocha-phantomjs-hooks.js\"}" \

--- a/test/test.js
+++ b/test/test.js
@@ -881,6 +881,18 @@ suite('fetch method', function() {
         })
       })
 
+      test('DataView body', function() {
+        return fetch('/request', {
+          method: 'post',
+          body: new DataView(arrayBufferFromText('name=Hubot'))
+        }).then(function(response) {
+          return response.json()
+        }).then(function(request) {
+          assert.equal(request.method, 'POST')
+          assert.equal(request.data, 'name=Hubot')
+        })
+      })
+
       test('TypedArray body', function() {
         return fetch('/request', {
           method: 'post',

--- a/test/test.js
+++ b/test/test.js
@@ -868,15 +868,29 @@ suite('fetch method', function() {
       })
     })
 
-    featureDependent(test, support.arrayBuffer, 'sends ArrayBuffer body', function() {
-      return fetch('/request', {
-        method: 'post',
-        body: arrayBufferFromText('name=Hubot')
-      }).then(function(response) {
-        return response.json()
-      }).then(function(request) {
-        assert.equal(request.method, 'POST')
-        assert.equal(request.data, 'name=Hubot')
+    featureDependent(suite, support.arrayBuffer, 'ArrayBuffer', function() {
+      test('ArrayBuffer body', function() {
+        return fetch('/request', {
+          method: 'post',
+          body: arrayBufferFromText('name=Hubot')
+        }).then(function(response) {
+          return response.json()
+        }).then(function(request) {
+          assert.equal(request.method, 'POST')
+          assert.equal(request.data, 'name=Hubot')
+        })
+      })
+
+      test('TypedArray body', function() {
+        return fetch('/request', {
+          method: 'post',
+          body: new Uint8Array(arrayBufferFromText('name=Hubot'))
+        }).then(function(response) {
+          return response.json()
+        }).then(function(request) {
+          assert.equal(request.method, 'POST')
+          assert.equal(request.data, 'name=Hubot')
+        })
       })
     })
 


### PR DESCRIPTION
Problem: passing ArrayBuffer directly to XHR is considered deprecated and Safari and PhantomJS will throw warnings about it. Instead, an ArrayBuffer should be wrapped in an ArrayBufferView instance. However, the polyfill used to reject those instances as unrecognized body types, and our users were not able to work around the deprecation warning. This adds support for those types and brings us closer to spec compatibility.

Supporting IE 10 & 11 complicates matters here, because `ArrayBuffer.isView` polyfill is needed for IE 10, and a special case for DataView objects is necessary for IE 10-11.

Fixes #344, fixes #343, references #351

/cc @dgraham