### PR TITLE
Remove incorrect set of bodyUsed flag when cloning a request

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -299,7 +299,7 @@
     return (methods.indexOf(upcased) > -1) ? upcased : method
   }
 
-  function Request(input, options) {
+  function Request(input, options, isCloneOperation) {
     options = options || {}
     var body = options.body
 
@@ -318,7 +318,9 @@
       this.mode = input.mode
       if (!body && input._bodyInit != null) {
         body = input._bodyInit
-        input.bodyUsed = true
+        if (!isCloneOperation) {
+          input.bodyUsed = true
+        }
       }
     }
 
@@ -337,7 +339,7 @@
   }
 
   Request.prototype.clone = function() {
-    return new Request(this, { body: this._bodyInit })
+    return new Request(this, { body: this._bodyInit }, true)
   }
 
   function decode(body) {


### PR DESCRIPTION
This removes setting bodyUsed to true when you clone a request.

In order to use a request multiple times you need to clone a request, which lets you get a copy of the request while leaving the original request as is, as long as you didn't read the request body beforehand.

In Chrome implementation for example cloning a request does not change the bodyUsed property to true, however in this polyfill it does.

This prevents you from cloning a request and passing on the original request as passing it causes the Already Read exception even though the body was not read directly from that request (by the end user).

**Polyfill scenario:**
https://runkit.com/58308876f439290014bb0025/5830907cf836f700146fa4f7

**Chrome Implementation scenario:** (open the browser console to see the output)
https://plnkr.co/edit/OVK9RREqhMm3WcgPtxOf?p=preview

Sorry for not having a single place for both scenarios. I could not find a snippet service that allows me to bring the package from npm.

**TL;DR**
bodyUsed should not be set to true when cloning a request on the original request