### PR TITLE
Replace catch in examples with `then` error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fetch('/users.json')
     return response.json()
   }).then(function(json) {
     console.log('parsed json', json)
-  }).catch(function(ex) {
+  }, function(ex) {
     console.log('parsing failed', ex)
   })
 ```
@@ -201,7 +201,7 @@ fetch('/users')
   .then(parseJSON)
   .then(function(data) {
     console.log('request succeeded with JSON response', data)
-  }).catch(function(error) {
+  }, function(error) {
     console.log('request failed', error)
   })
 ```


### PR DESCRIPTION
Suggesting to use `.catch()` in your examples lead newer developper to mislead potential code errors for a network failures.

This is pretty bad because it hides away legitimate code errors we'd want to catch and logs for future fixes (or immediate developper attention in the devtool console).

By using the `then(onSuccess, onError)`, we're "sure" the error handler is triggered when a network failure occurred. Using `.catch()`, you'll actually be handling network failure AND any exception raised inside the `.then()` success handler.