### PR TITLE
Support Tolerance Provision when parsing headers

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -355,7 +355,7 @@
 
   function parseHeaders(rawHeaders) {
     var headers = new Headers()
-    rawHeaders.split('\r\n').forEach(function(line) {
+    rawHeaders.split(/\r?\n/).forEach(function(line) {
       var parts = line.split(':')
       var key = parts.shift().trim()
       if (key) {


### PR DESCRIPTION
The change to fix this issue https://github.com/github/fetch/issues/422 has created another issue for our app on devices running iOS 8.2 and iOS 9. The impact prevents these users from using our app entirely.

More specifically, the result of splitting by `\r\n` and not both `\r\n` and `\n` is a malformed response header with all the actual headers put into the 'pragma' key and a content type of `text/plain;charset=UTF-8` instead of `application/json`.

Source:
http://stackoverflow.com/a/5757349
more specifically, https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.3