### PR TITLE
Treat any non-Request arg to `new Request()` as string url

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -303,9 +303,7 @@
     options = options || {}
     var body = options.body
 
-    if (typeof input === 'string') {
-      this.url = input
-    } else {
+    if (input instanceof Request) {
       if (input.bodyUsed) {
         throw new TypeError('Already read')
       }
@@ -320,6 +318,8 @@
         body = input._bodyInit
         input.bodyUsed = true
       }
+    } else {
+      this.url = String(input)
     }
 
     this.credentials = options.credentials || this.credentials || 'omit'

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,12 @@
 var support = {
   searchParams: 'URLSearchParams' in self,
-  url: 'URL' in self,
+  url: (function(url) {
+    try {
+      return new URL(url).toString() === url
+    } catch(e) {
+      return false
+    }
+  })('http://example.com/'),
   blob: 'FileReader' in self && 'Blob' in self && (function() {
     try {
       new Blob()

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var support = {
   searchParams: 'URLSearchParams' in self,
+  url: 'URL' in self,
   blob: 'FileReader' in self && 'Blob' in self && (function() {
     try {
       new Blob()
@@ -283,8 +284,21 @@ suite('Headers', function() {
 
 // https://fetch.spec.whatwg.org/#request-class
 suite('Request', function() {
-  test('construct with url', function() {
+  test('construct with string url', function() {
     var request = new Request('https://fetch.spec.whatwg.org/')
+    assert.equal(request.url, 'https://fetch.spec.whatwg.org/')
+  })
+
+  featureDependent(test, support.url, 'construct with URL instance', function() {
+    var url = new URL('https://fetch.spec.whatwg.org/')
+    url.pathname = 'cors'
+    var request = new Request(url)
+    assert.equal(request.url, 'https://fetch.spec.whatwg.org/cors')
+  })
+
+  test('construct with non-Request object', function() {
+    var url = { toString: function() { return 'https://fetch.spec.whatwg.org/' } }
+    var request = new Request(url)
     assert.equal(request.url, 'https://fetch.spec.whatwg.org/')
   })
 


### PR DESCRIPTION
This aims to match the behavior that the IDL of the spec defines.

Fixes https://github.com/github/fetch/issues/462

/cc @dgraham