### PR TITLE
Added safari to native fetch browser support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Firefox < 32, Chrome < 37, Safari, or IE.
 - Safari 6.1+
 - Internet Explorer 10+
 
-Note: modern browsers such as Chrome, Firefox, and Microsoft Edge contain native
+Note: modern browsers such as Chrome, Firefox, Microsoft Edge and Safari contain native
 implementations of `window.fetch`, therefore the code from this polyfill doesn't
 have any effect on those browsers. If you believe you've encountered an error
 with how `window.fetch` is implemented in any of these browsers, you should file

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Firefox < 32, Chrome < 37, Safari, or IE.
 - Safari 6.1+
 - Internet Explorer 10+
 
-Note: modern browsers such as Chrome, Firefox, Microsoft Edge and Safari contain native
+Note: modern browsers such as Chrome, Firefox, Microsoft Edge, and Safari contain native
 implementations of `window.fetch`, therefore the code from this polyfill doesn't
 have any effect on those browsers. If you believe you've encountered an error
 with how `window.fetch` is implemented in any of these browsers, you should file


### PR DESCRIPTION
Safari 10.1 now natively supports fetch. https://developer.apple.com/library/prerelease/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html