### PR TITLE
Accept array in Headers constructor

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -84,7 +84,10 @@
       headers.forEach(function(value, name) {
         this.append(name, value)
       }, this)
-
+    } else if (Array.isArray(headers)) {
+      headers.forEach(function(header) {
+        this.append(header[0], header[1]);
+      }, this);
     } else if (headers) {
       Object.getOwnPropertyNames(headers).forEach(function(name) {
         this.append(name, headers[name])

--- a/test/test.js
+++ b/test/test.js
@@ -170,6 +170,16 @@ suite('Headers', function() {
     assert.equal(headers.get('Accept'), 'application/json,text/plain')
     assert.equal(headers.get('Content-type'), 'text/html')
   })
+  test('constructor works with arrays', function() {
+    var array = [
+      ['Content-Type', 'text/xml'],
+      ['Breaking-Bad', '<3']
+    ];
+    var headers = new Headers(array)
+
+    assert.equal(headers.get('Content-Type'), 'text/xml')
+    assert.equal(headers.get('Breaking-Bad'), '<3')
+  })
   test('headers are case insensitive', function() {
     var headers = new Headers({'Accept': 'application/json'})
     assert.equal(headers.get('ACCEPT'), 'application/json')


### PR DESCRIPTION
[From the spec](https://fetch.spec.whatwg.org/#typedefdef-headersinit), it looks like the `Headers` constructor should accept an array of arrays.

I've adapted [the example](https://fetch.spec.whatwg.org/#example-headers-class) for the tests:
```js
var meta = { "Content-Type": "text/xml", "Breaking-Bad": "<3" }
new Headers(meta)

// The above is equivalent to
var meta = [
  [ "Content-Type", "text/xml" ],
  [ "Breaking-Bad", "<3" ]
]
new Headers(meta)
```

This came up for me as an issue using `stream-http` in Edge with the Financial Times polyfill.  I've opened jhiesey/stream-http#71 and Financial-Times/polyfill-service#1091 in case this can be addressed elsewhere, but it looks to me like this might be the right fix.
