### PR TITLE
Add global replace for processing raw headers

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -360,7 +360,7 @@
     var headers = new Headers()
     // Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
     // https://tools.ietf.org/html/rfc7230#section-3.2
-    var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/, ' ')
+    var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ')
     preProcessedHeaders.split(/\r?\n/).forEach(function(line) {
       var parts = line.split(':')
       var key = parts.shift().trim()


### PR DESCRIPTION
@mislav @mpfluger

Added global replace as @pseidemann mentioned.
https://github.com/github/fetch/pull/491#issuecomment-284801588

Not sure how you would want to expose `parseHeaders` for testing but here are some suggestions for tests:

```
suite('parseHeaders', function() {
  test('parses raw headers with line feed'), function() {
    var rawHeaders = 'Tolerance-Provision-Value-1: key1\nTolerance-Provision-Value-2: key2\nTolerance-Provision-Value-3: key3'
    var headers = parseHeaders(rawHeaders);
    assert.equal(headers.get('Tolerance-Provision-Value-1'),'key1')
    assert.equal(headers.get('Tolerance-Provision-Value-2'),'key2')
    assert.equal(headers.get('Tolerance-Provision-Value-3'),'key3')
  })
  test('parses raw headers with carriage return line feed'), function() {
    var rawHeaders = 'Basic-Rules-Value-1: key1\r\nBasic-Rules-Value-2: key2\r\nBasic-Rules-Value-3: key3'
    var headers = parseHeaders(rawHeaders);
    assert.equal(headers.get('Basic-Rules-Value-1'),'key1')
    assert.equal(headers.get('Basic-Rules-Value-2'),'key2')
    assert.equal(headers.get('Basic-Rules-Value-3'),'key3')
  })
  test('parses raw headers with obs-fold'), function() {
    var rawHeaders = 'Obs-Fold-Value: key1\r\n key2\r\n key3'
    var headers = parseHeaders(rawHeaders);
    assert.equal(headers.get('Obs-Fold-Value'),'key1 key2 key3')
  })
})
```