### PR TITLE
Allow `:` in headers

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -46,7 +46,7 @@
     if (typeof name !== 'string') {
       name = String(name)
     }
-    if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
+    if (/[^a-z0-9\-#$%&'*+.\^_`|~\:]/i.test(name)) {
       throw new TypeError('Invalid character in header field name')
     }
     return name.toLowerCase()


### PR DESCRIPTION
Here's a request's header:

```
:authority:jandan.net
:method:GET
:path:/ooxx
:scheme:https
accept:text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8

...
```

see https://jandan.net/ooxx