### PR TITLE
Add additional fallbacks when self is undefined

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,6 +1,10 @@
 (function(self) {
   'use strict';
 
+  if (!self) {
+    throw new Error('Fetch polyfill was unable to access the global object');
+  }
+
   if (self.fetch) {
     return
   }
@@ -461,4 +465,9 @@
     })
   }
   self.fetch.polyfill = true
-})(typeof self !== 'undefined' ? self : this);
+})(
+/* jshint ignore:start */
+/* we expect some of these to be undefined */
+  typeof self !== 'undefined' ? self : typeof this !== 'undefined' ? this : typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : null
+/* jshint ignore:end */
+);


### PR DESCRIPTION
This extends the solution in #253 for React Native compatibility. 

The existing `this` fallback is inadequate because in strict mode `this` is undefined outside of class methods rather than defaulting to the global object.