### PR TITLE
Ensure cookies aren't sent if `credentials: omit`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -447,6 +447,8 @@
 
       if (request.credentials === 'include') {
         xhr.withCredentials = true
+      } else if (request.credentials === 'omit') {
+        xhr.withCredentials = false
       }
 
       if ('responseType' in xhr && support.blob) {


### PR DESCRIPTION
If the default value of `withCredentials` is `true`, as opposed to `false`, the library will send the cookies even if `credentials: omit` is specified. This affects React Native where the default value is `true` since cross-origin concerns don't apply.