### PR TITLE
Allow undefined Response status

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -380,7 +380,7 @@
     }
 
     this.type = 'default'
-    this.status = 'status' in options ? options.status : 200
+    this.status = options.status === undefined ? 200 : options.status
     this.ok = this.status >= 200 && this.status < 300
     this.statusText = 'statusText' in options ? options.statusText : 'OK'
     this.headers = new Headers(options.headers)

--- a/test/test.js
+++ b/test/test.js
@@ -521,6 +521,13 @@ suite('Response', function() {
     assert.isTrue(res.ok)
   })
 
+  test('default status is 200 OK when an explicit undefined status code is passed', function() {
+    var res = new Response('', {status: undefined})
+    assert.equal(res.status, 200)
+    assert.equal(res.statusText, 'OK')
+    assert.isTrue(res.ok)
+  })
+
   testBodyExtract(function(body) {
     return new Response(body)
   })


### PR DESCRIPTION
This allows the Response constructor to accept a status code that's
explicitly set to undefined. Native fetch implementations in Chrome and
Firefox behave this way.

The following now works, but would previously throw an error:

    new Response('', { status: undefined })