### PR TITLE
add normalization for PATCH method

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -295,7 +295,7 @@
   }
 
   // HTTP methods whose capitalization should be normalized
-  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']
 
   function normalizeMethod(method) {
     var upcased = method.toUpperCase()

--- a/test/test.js
+++ b/test/test.js
@@ -1026,6 +1026,18 @@ suite('HTTP methods', function() {
     })
   })
 
+  test('supports HTTP PATCH', function() {
+    return fetch('/request', {
+      method: 'patch',
+      body: 'name=Hubot'
+    }).then(function(response) {
+      return response.json()
+    }).then(function(request) {
+      assert.equal(request.method, 'PATCH')
+      assert.equal(request.data, 'name=Hubot')
+    })
+  })
+
   featureDependent(test, support.patch, 'supports HTTP PATCH', function() {
     return fetch('/request', {
       method: 'PATCH',


### PR DESCRIPTION
Previously when passing lowercase method `patch`, the library will let it pass as it is. This causes some reverse proxy to reject the request. 

This change expanded the normalization function to include `patch`