### PR TITLE
Add caveat about disabling same-origin cookies

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,5 +305,6 @@ More comprehensive usage example:
   <ul>
     <li>Inability to <a href="https://github.com/github/fetch/issues/137">set the redirect mode</a></li>
     <li>Inability to <a href="https://github.com/github/fetch/issues/438#issuecomment-261272466">change the cache directive</a></li>
+    <li>Inability to <a href="https://github.com/github/fetch/pull/56#issuecomment-68835992">disable same-origin cookies</a></li>
   </ul>
 </section>


### PR DESCRIPTION
Because of the spec of XMLHttpRequest, `fetch` polyfill can't prevent sending and receiving same-origin cookies when `credentials: 'omit'`.
This behavior is very confusing when app supports both modern and legacy browsers.
I think this should be clearly documented as a caveat.
