### PR TITLE
Tweak the wording of the “Read this first” section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,32 @@ expected to uphold this code.
 ## Read this first
 
 * If you believe you found a bug with how `fetch` behaves in Chrome or Firefox,
-  please **avoid opening an issue in this repository**. This project is a
+  please **don't open an issue in this repository**. This project is a
   _polyfill_, and since Chrome and Firefox both implement the `window.fetch`
   function natively, no code from this project actually takes any effect in
   these browsers. See [Browser support](#browser-support) for detailed
   information.
 
 * If you have trouble **making a request to another domain** (a different
-  subdomain or port number also constitutes as another domain), please
-  familiarize yourself with all the intricacies and limitations of [CORS][]
-  requests. Because CORS requires participation of the server by implementing
-  specific HTTP response headers, it is often nontrivial to set up or debug.
-  CORS is exclusively handled by the browser's internal mechanisms which this
-  polyfill cannot influence.
+  subdomain or port number also constitutes another domain), please familiarize
+  yourself with all the intricacies and limitations of [CORS][] requests.
+  Because CORS requires participation of the server by implementing specific
+  HTTP response headers, it is often nontrivial to set up or debug. CORS is
+  exclusively handled by the browser's internal mechanisms which this polyfill
+  cannot influence.
 
 * If you have trouble **maintaining the user's session** or [CSRF][] protection
   through `fetch` requests, please ensure that you've read and understood the
-  [Sending cookies](#sending-cookies) section.
+  [Sending cookies](#sending-cookies) section. `fetch` doesn't send cookies
+  unless you ask it to.
 
-* If this polyfill **doesn't work under Node.js environments**, that is expected,
-  because this project is meant for web browsers only. You should ensure that your
-  application doesn't try to package and run this on the server.
+* This project **doesn't work under Node.js environments**. It's meant for web
+  browsers only. You should ensure that your application doesn't try to package
+  and run this on the server.
 
-* If you have an idea for a new feature of `fetch`, please understand that we
-  are only ever going to add features and APIs that are a part of the
-  [Fetch specification][]. You should **submit your feature requests** to the
-  [repository of the specification](https://github.com/whatwg/fetch/issues)
-  itself, rather than this repository.
+* If you have an idea for a new feature of `fetch`, **submit your feature
+  requests** to the [specification's repository](https://github.com/whatwg/fetch/issues).
+  We only add features and APIs that are part of the [Fetch specification][].
 
 ## Installation
 


### PR DESCRIPTION
I found the bullet on node.js particularly confusing. This breaks the parallel structure, but I think it's worth it. Made a few more edits while I was at it.