### PR TITLE
Change error message for xhr.ontimeout

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -440,7 +440,7 @@
       }
 
       xhr.ontimeout = function() {
-        reject(new TypeError('Network request failed'))
+        reject(new TypeError('Network request timed out'))
       }
 
       xhr.open(request.method, request.url, true)


### PR DESCRIPTION
At the moment xhr.onerror and xhr.ontimeout do write the same error
message of TypeError('Network request failed') to distiguish between
this commit changes the error message for the timeout.