### PR TITLE
Change `credentials` default value to `same-origin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ fetch('/avatars', {
   and it will only reject on network failure or if anything prevented the
   request from completing.
 
+* For maximum browser compatibility when it comes to sending & receiving
+  cookies, always supply the `credentials: 'same-origin'` option instead of
+  relying on the default. See [Sending cookies](#sending-cookies).
+
 #### Handling HTTP error statuses
 
 To have `fetch` Promise reject on HTTP error statuses, i.e. on any non-2xx

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ fetch('/users')
 
 #### Sending cookies
 
-For [CORS][] requests, use the "include" value to allow sending credentials to
-other domains:
+For [CORS][] requests, use `credentials: 'include'` to allow sending credentials
+to other domains:
 
 ```javascript
 fetch('https://example.com:1234/users', {
@@ -207,8 +207,8 @@ fetch('https://example.com:1234/users', {
 })
 ```
 
-To disable sending or receiving cookies for requests to the same domain, use
-the "omit" value:
+To disable sending or receiving cookies for requests to any domain, including
+the current one, use the "omit" value:
 
 ```javascript
 fetch('/users', {
@@ -216,7 +216,25 @@ fetch('/users', {
 })
 ```
 
-The default value is `credentials: 'same-origin'`.
+The default value for `credentials` is "same-origin".
+
+The default for `credentials` wasn't always the same, though. The following
+versions of browsers implemented an older version of the fetch specification
+where the default was "omit":
+
+* Firefox 39-60
+* Chrome 42-67
+* Safari 10.1-11.1.2
+
+If you target these browsers, it's advisable to always specify `credentials:
+'same-origin'` explicitly with all fetch requests instead of relying on the
+default:
+
+```javascript
+fetch('/users', {
+  credentials: 'same-origin'
+})
+```
 
 #### Receiving cookies
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,6 @@ expected to uphold this code.
   exclusively handled by the browser's internal mechanisms which this polyfill
   cannot influence.
 
-* If you have trouble **maintaining the user's session** or [CSRF][] protection
-  through `fetch` requests, please ensure that you've read and understood the
-  [Sending cookies](#sending-cookies) section. `fetch` doesn't send cookies
-  unless you ask it to.
-
 * This project **doesn't work under Node.js environments**. It's meant for web
   browsers only. You should ensure that your application doesn't try to package
   and run this on the server.
@@ -166,18 +161,10 @@ fetch('/avatars', {
 
 ### Caveats
 
-The `fetch` specification differs from `jQuery.ajax()` in mainly two ways that
-bear keeping in mind:
-
 * The Promise returned from `fetch()` **won't reject on HTTP error status**
   even if the response is an HTTP 404 or 500. Instead, it will resolve normally,
   and it will only reject on network failure or if anything prevented the
   request from completing.
-
-* By default, `fetch` **won't send or receive any cookies** from the server,
-  resulting in unauthenticated requests if the site relies on maintaining a user
-  session. See [Sending cookies](#sending-cookies) for how to opt into cookie
-  handling.
 
 #### Handling HTTP error statuses
 
@@ -211,19 +198,6 @@ fetch('/users')
 
 #### Sending cookies
 
-To automatically send cookies for the current domain, the `credentials` option
-must be provided:
-
-```javascript
-fetch('/users', {
-  credentials: 'same-origin'
-})
-```
-
-The "same-origin" value makes `fetch` behave similarly to XMLHttpRequest with
-regards to cookies. Otherwise, cookies won't get sent, resulting in these
-requests not preserving the authentication session.
-
 For [CORS][] requests, use the "include" value to allow sending credentials to
 other domains:
 
@@ -233,6 +207,17 @@ fetch('https://example.com:1234/users', {
 })
 ```
 
+To disable sending or receiving cookies for requests to the same domain, use
+the "omit" value:
+
+```javascript
+fetch('/users', {
+  credentials: 'omit'
+})
+```
+
+The default value is `credentials: 'same-origin'`.
+
 #### Receiving cookies
 
 As with XMLHttpRequest, the `Set-Cookie` response header returned from the
@@ -240,10 +225,6 @@ server is a [forbidden header name][] and therefore can't be programmatically
 read with `response.headers.get()`. Instead, it's the browser's responsibility
 to handle new cookies being set (if applicable to the current URL). Unless they
 are HTTP-only, new cookies will be available through `document.cookie`.
-
-Bear in mind that the default behavior of `fetch` is to ignore the `Set-Cookie`
-header completely. To opt into accepting cookies from the server, you must use
-the `credentials` option.
 
 #### Obtaining the Response URL
 

--- a/fetch.js
+++ b/fetch.js
@@ -330,7 +330,7 @@ export function Request(input, options) {
     this.url = String(input)
   }
 
-  this.credentials = options.credentials || this.credentials || 'omit'
+  this.credentials = options.credentials || this.credentials || 'same-origin'
   if (options.headers || !this.headers) {
     this.headers = new Headers(options.headers)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -540,6 +540,16 @@ exercise.forEach(function(exerciseMode) {
       testBodyExtract(function(body) {
         return new Request('', {method: 'POST', body: body})
       })
+
+      test('credentials defaults to same-origin', function() {
+        var request = new Request('')
+        assert.equal(request.credentials, 'same-origin')
+      })
+
+      test('credentials is overridable', function() {
+        var request = new Request('', {credentials: 'omit'})
+        assert.equal(request.credentials, 'omit')
+      })
     })
 
     // https://fetch.spec.whatwg.org/#response-class
@@ -1347,24 +1357,6 @@ exercise.forEach(function(exerciseMode) {
         })
 
         featureDependent(suite, exerciseMode === 'native', 'omit', function() {
-          test('request credentials defaults to omit', function() {
-            var request = new Request('')
-            assert.equal(request.credentials, 'omit')
-          })
-
-          test('does not accept cookies with implicit omit credentials', function() {
-            return fetch('/cookie?name=foo&value=bar')
-              .then(function() {
-                return fetch('/cookie?name=foo', {credentials: 'same-origin'})
-              })
-              .then(function(response) {
-                return response.text()
-              })
-              .then(function(data) {
-                assert.equal(data, 'reset')
-              })
-          })
-
           test('does not accept cookies with omit credentials', function() {
             return fetch('/cookie?name=foo&value=bar', {credentials: 'omit'})
               .then(function() {
@@ -1375,19 +1367,6 @@ exercise.forEach(function(exerciseMode) {
               })
               .then(function(data) {
                 assert.equal(data, 'reset')
-              })
-          })
-
-          test('does not send cookies with implicit omit credentials', function() {
-            return fetch('/cookie?name=foo&value=bar', {credentials: 'same-origin'})
-              .then(function() {
-                return fetch('/cookie?name=foo')
-              })
-              .then(function(response) {
-                return response.text()
-              })
-              .then(function(data) {
-                assert.equal(data, '')
               })
           })
 
@@ -1406,11 +1385,6 @@ exercise.forEach(function(exerciseMode) {
         })
 
         suite('same-origin', function() {
-          test('request credentials uses inits member', function() {
-            var request = new Request('', {credentials: 'same-origin'})
-            assert.equal(request.credentials, 'same-origin')
-          })
-
           test('send cookies with same-origin credentials', function() {
             return fetch('/cookie?name=foo&value=bar', {credentials: 'same-origin'})
               .then(function() {


### PR DESCRIPTION
Spec changed in April: https://github.com/whatwg/fetch/pull/585

Latest Firefox and Chrome implement the new default.