### PR TITLE
Match spec behavior re: unsupported body type

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -227,7 +227,7 @@ function Body() {
     } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
       this._bodyArrayBuffer = bufferClone(body)
     } else {
-      throw new Error('unsupported BodyInit type')
+      this._bodyText = body = Object.prototype.toString.call(body)
     }
 
     if (!this.headers.get('content-type')) {

--- a/test/test.js
+++ b/test/test.js
@@ -493,6 +493,29 @@ exercise.forEach(function(exerciseMode) {
         }
       )
 
+      test('construct with unsupported body type', function() {
+        var req = new Request('https://fetch.spec.whatwg.org/', {
+          method: 'post',
+          body: {}
+        })
+
+        assert.equal(req.headers.get('content-type'), 'text/plain;charset=UTF-8')
+        return req.text().then(function(bodyText) {
+          assert.equal(bodyText, '[object Object]')
+        })
+      })
+
+      test('construct with null body', function() {
+        var req = new Request('https://fetch.spec.whatwg.org/', {
+          method: 'post'
+        })
+
+        assert.isNull(req.headers.get('content-type'))
+        return req.text().then(function(bodyText) {
+          assert.equal(bodyText, '')
+        })
+      })
+
       test('clone GET request', function() {
         var req = new Request('https://fetch.spec.whatwg.org/', {
           headers: {'content-type': 'text/plain'}
@@ -642,6 +665,30 @@ exercise.forEach(function(exerciseMode) {
         })
 
         assert.equal(r.headers.get('content-type'), 'text/plain')
+      })
+
+      test('init object as first argument', function() {
+        var r = new Response({
+          status: 201,
+          headers: {
+            'Content-Type': 'text/html'
+          }
+        })
+
+        assert.equal(r.status, 200)
+        assert.equal(r.headers.get('content-type'), 'text/plain;charset=UTF-8')
+        return r.text().then(function(bodyText) {
+          assert.equal(bodyText, '[object Object]')
+        })
+      })
+
+      test('null as first argument', function() {
+        var r = new Response(null)
+
+        assert.isNull(r.headers.get('content-type'))
+        return r.text().then(function(bodyText) {
+          assert.equal(bodyText, '')
+        })
       })
     })
 


### PR DESCRIPTION
The polyfill used to throw an exception, but the spec dictates that unsupported body types are simply converted to string.

Closes #576, closes #642