### PR TITLE
Add support for Cloudflare Request Attributes

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -338,6 +338,7 @@ export function Request(input, options) {
   this.mode = options.mode || this.mode || null
   this.signal = options.signal || this.signal
   this.referrer = null
+  this.cf = options.cf || {}
 
   if ((this.method === 'GET' || this.method === 'HEAD') && body) {
     throw new TypeError('Body not allowed for GET or HEAD requests')

--- a/test/test.js
+++ b/test/test.js
@@ -410,6 +410,11 @@ exercise.forEach(function(exerciseMode) {
         })
       })
 
+      test('construct with Cloudflare Request Attribute', function() {
+        var request = new Request('https://fetch.spec.whatwg.org/', {cf: {country: 'AUS'}})
+        assert.equal(request.cf, {country: 'AUS'})
+      })
+
       featureDependent(test, !nativeChrome, 'construct with used Request body', function() {
         var request1 = new Request('https://fetch.spec.whatwg.org/', {
           method: 'post',


### PR DESCRIPTION
Cloudflare workers now includes [Request Attributes](https://developers.cloudflare.com/workers/reference/request-attributes/). These attributes are accessible every request from the cf object. i.e: `request.cf`.

This PR allows us to set and get the request attribute from `request.cf`.

To set a cloudflare request attribute:

```js
const request = new Request('https://example.com', {cf: {country: 'AUS'}})
```

To access the request attribute:

```js
request.cf
```