### PR TITLE
field name can not by empty

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -44,7 +44,7 @@ function normalizeName(name) {
   if (typeof name !== 'string') {
     name = String(name)
   }
-  if (/[^a-z0-9\-#$%&'*+.^_`|~]/i.test(name)) {
+  if (/[^a-z0-9\-#$%&'*+.^_`|~]/i.test(name) || name === '') {
     throw new TypeError('Invalid character in header field name')
   }
   return name.toLowerCase()

--- a/test/test.js
+++ b/test/test.js
@@ -262,6 +262,9 @@ exercise.forEach(function(exerciseMode) {
           var headers = new Headers()
           headers.set({field: 'value'}, 'application/json')
         }, TypeError)
+        assert.throws(function() {
+          new Headers({'': 'application/json'})
+        }, TypeError)
       })
       featureDependent(test, !brokenFF, 'is iterable with forEach', function() {
         var headers = new Headers()


### PR DESCRIPTION
header-name can not by empty string

https://tools.ietf.org/html/rfc7230#section-3.2

```
header-field   = field-name ":" OWS field-value OWS

field-name     = token
field-value    = *( field-content / obs-fold )
field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
field-vchar    = VCHAR / obs-text

obs-fold       = CRLF 1*( SP / HTAB )
               ; obsolete line folding
               ; see Section 3.2.4
```

**Browser Compatibility:**

Firefox:

```js
let headers = new Headers();
headers.set('', 'foo');  // TypeError:  is an invalid header name.
```

Chrome:

```js
let headers = new Headers();
headers.set('', 'foo');  // TypeError: Failed to execute 'set' on 'Headers': Invalid name
```