### PR TITLE
Change default statusText for Response

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -391,7 +391,7 @@ export function Response(bodyInit, options) {
   this.type = 'default'
   this.status = options.status === undefined ? 200 : options.status
   this.ok = this.status >= 200 && this.status < 300
-  this.statusText = 'statusText' in options ? options.statusText : 'OK'
+  this.statusText = 'statusText' in options ? options.statusText : ''
   this.headers = new Headers(options.headers)
   this.url = options.url || ''
   this._initBody(bodyInit)

--- a/test/test.js
+++ b/test/test.js
@@ -604,24 +604,6 @@ exercise.forEach(function(exerciseMode) {
           assert.isTrue(res.ok)
         }
       )
-      featureDependent(test, !emptyDefaultStatusText, 'default status is 200 OK', function() {
-        var res = new Response()
-        assert.equal(res.status, 200)
-        assert.equal(res.statusText, 'OK')
-        assert.isTrue(res.ok)
-      })
-
-      featureDependent(
-        test,
-        !emptyDefaultStatusText,
-        'default status is 200 OK when an explicit undefined status code is passed',
-        function() {
-          var res = new Response('', {status: undefined})
-          assert.equal(res.status, 200)
-          assert.equal(res.statusText, 'OK')
-          assert.isTrue(res.ok)
-        }
-      )
 
       testBodyExtract(function(body) {
         return new Response(body)

--- a/test/test.js
+++ b/test/test.js
@@ -123,6 +123,8 @@ exercise.forEach(function(exerciseMode) {
     var nativeEdge = /Edge\//.test(navigator.userAgent) && exerciseMode === 'native'
     var firefox = navigator.userAgent.match(/Firefox\/(\d+)/)
     var brokenFF = firefox && firefox[1] <= 56 && exerciseMode === 'native'
+    var emptyDefaultStatusText =
+      exerciseMode !== 'native' || (exerciseMode === 'native' && (Chrome || (firefox && firefox[1] >= 67)))
     var polyfillFirefox = firefox && exerciseMode === 'polyfill'
     var omitSafari =
       Safari && exerciseMode === 'native' && navigator.userAgent.match(/Version\/(\d+\.\d+)/)[1] <= '11.1'
@@ -584,19 +586,60 @@ exercise.forEach(function(exerciseMode) {
 
     // https://fetch.spec.whatwg.org/#response-class
     suite('Response', function() {
-      test('default status is 200 OK', function() {
+      featureDependent(test, emptyDefaultStatusText, "default status is 200 ''", function() {
+        var res = new Response()
+        assert.equal(res.status, 200)
+        assert.equal(res.statusText, '')
+        assert.isTrue(res.ok)
+      })
+
+      featureDependent(
+        test,
+        emptyDefaultStatusText,
+        "default status is 200 '' when an explicit undefined status code is passed",
+        function() {
+          var res = new Response('', {status: undefined})
+          assert.equal(res.status, 200)
+          assert.equal(res.statusText, '')
+          assert.isTrue(res.ok)
+        }
+      )
+      featureDependent(test, !emptyDefaultStatusText, 'default status is 200 OK', function() {
         var res = new Response()
         assert.equal(res.status, 200)
         assert.equal(res.statusText, 'OK')
         assert.isTrue(res.ok)
       })
 
-      test('default status is 200 OK when an explicit undefined status code is passed', function() {
-        var res = new Response('', {status: undefined})
+      featureDependent(
+        test,
+        !emptyDefaultStatusText,
+        'default status is 200 OK when an explicit undefined status code is passed',
+        function() {
+          var res = new Response('', {status: undefined})
+          assert.equal(res.status, 200)
+          assert.equal(res.statusText, 'OK')
+          assert.isTrue(res.ok)
+        }
+      )
+      featureDependent(test, exerciseMode !== 'native', "default status is 200 ''", function() {
+        var res = new Response()
         assert.equal(res.status, 200)
-        assert.equal(res.statusText, 'OK')
+        assert.equal(res.statusText, '')
         assert.isTrue(res.ok)
       })
+
+      featureDependent(
+        test,
+        exerciseMode !== 'native',
+        "default status is 200 '' when an explicit undefined status code is passed",
+        function() {
+          var res = new Response('', {status: undefined})
+          assert.equal(res.status, 200)
+          assert.equal(res.statusText, '')
+          assert.isTrue(res.ok)
+        }
+      )
 
       testBodyExtract(function(body) {
         return new Response(body)

--- a/test/test.js
+++ b/test/test.js
@@ -586,7 +586,7 @@ exercise.forEach(function(exerciseMode) {
 
     // https://fetch.spec.whatwg.org/#response-class
     suite('Response', function() {
-      featureDependent(test, emptyDefaultStatusText, "default status is 200 ''", function() {
+      featureDependent(test, emptyDefaultStatusText, 'default status is 200', function() {
         var res = new Response()
         assert.equal(res.status, 200)
         assert.equal(res.statusText, '')
@@ -596,7 +596,7 @@ exercise.forEach(function(exerciseMode) {
       featureDependent(
         test,
         emptyDefaultStatusText,
-        "default status is 200 '' when an explicit undefined status code is passed",
+        'default status is 200 when an explicit undefined status code is passed',
         function() {
           var res = new Response('', {status: undefined})
           assert.equal(res.status, 200)
@@ -619,24 +619,6 @@ exercise.forEach(function(exerciseMode) {
           var res = new Response('', {status: undefined})
           assert.equal(res.status, 200)
           assert.equal(res.statusText, 'OK')
-          assert.isTrue(res.ok)
-        }
-      )
-      featureDependent(test, exerciseMode !== 'native', "default status is 200 ''", function() {
-        var res = new Response()
-        assert.equal(res.status, 200)
-        assert.equal(res.statusText, '')
-        assert.isTrue(res.ok)
-      })
-
-      featureDependent(
-        test,
-        exerciseMode !== 'native',
-        "default status is 200 '' when an explicit undefined status code is passed",
-        function() {
-          var res = new Response('', {status: undefined})
-          assert.equal(res.status, 200)
-          assert.equal(res.statusText, '')
           assert.isTrue(res.ok)
         }
       )


### PR DESCRIPTION
According to [WHATWG fetch specification](https://fetch.spec.whatwg.org/#response-class) default statusText for Response should be "" (empty string).

Fixes #696 