### PR TITLE
Provide Window Global to Verify Polyfill Load

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -514,3 +514,5 @@ if (!self.fetch) {
   self.Request = Request
   self.Response = Response
 }
+
+self.WHATWGFetch = true

--- a/fetch.js
+++ b/fetch.js
@@ -514,5 +514,3 @@ if (!self.fetch) {
   self.Request = Request
   self.Response = Response
 }
-
-// self.WHATWGFetch = true

--- a/fetch.js
+++ b/fetch.js
@@ -515,4 +515,4 @@ if (!self.fetch) {
   self.Response = Response
 }
 
-self.WHATWGFetch = true
+// self.WHATWGFetch = true

--- a/fetch.js
+++ b/fetch.js
@@ -515,4 +515,4 @@ if (!self.fetch) {
   self.Response = Response
 }
 
-self.WHATWGFetch = true
+self._whatwgFetchPolyfill = true


### PR DESCRIPTION
At the company I work for we leverage integration tests to verify our browser compatibility. One portion of that is verifying that we have properly loaded our polyfills. It would be beneficial to have some kind of window global variable that allowed us to determine if the polyfilling script was loaded on the page (whether or not the polyfill was necessary).

This feature is currently in `@babel/polyfill`:
```js
window._babelPolyfill; // true
```
It is also available in `core-js`:
```js
window.core.version; // "{major}.{minor}.{patch}" - a semver string
```

I do not care what the variable is called or how the result is formatted - I would just like some way to verify that this polyfilling script has loaded.