### PR TITLE
Compatibility for fetch-mock using proxy-pollyfill

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -209,6 +209,7 @@ function Body() {
   this.bodyUsed = false
 
   this._initBody = function(body) {
+    this.bodyUsed = this.bodyUsed // copy prototype to instance for proxy-pollyfill
     this._bodyInit = body
     if (!body) {
       this._bodyText = ''

--- a/fetch.js
+++ b/fetch.js
@@ -209,7 +209,17 @@ function Body() {
   this.bodyUsed = false
 
   this._initBody = function(body) {
-    this.bodyUsed = this.bodyUsed // copy prototype to instance for proxy-pollyfill
+    /*
+      fetch-mock wraps the Response object in an ES6 Proxy to
+      provide useful test harness features such as flush. However, on
+      ES5 browsers without fetch or Proxy support pollyfills must be used;
+      the proxy-pollyfill is unable to proxy an attribute unless it exists
+      on the object before the Proxy is created. This change ensures
+      Response.bodyUsed exists on the instance, while maintaining the
+      semantic of setting Request.bodyUsed in the constructor before
+      _initBody is called.
+    */
+    this.bodyUsed = this.bodyUsed
     this._bodyInit = body
     if (!body) {
       this._bodyText = ''


### PR DESCRIPTION
Fixes wheresrhys/fetch-mock#415

Details: fetch-mock wraps the Response object in an ES6 Proxy to
provide useful test harness features such as flush.  However, on
ES5 browsers without fetch or Proxy support pollyfills must be used;
the proxy-pollyfill is unable to proxy an attribute unless it exists
on the object before the Proxy is created.  This change ensures
Response.bodyUsed exists on the instance, while maintaining the
semantic of setting Request.bodyUsed in the constructor before
_initBody is called.