### PR TITLE
Allow reading FormData body back from request.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -287,6 +287,14 @@ function Body() {
 
   if (support.formData) {
     this.formData = function() {
+      if (this._bodyFormData) {
+        var rejected = consumed(this)
+        if (rejected) {
+          return rejected
+        }
+        return Promise.resolve(cloneFormData(this._bodyFormData))
+      }
+
       return this.text().then(decode)
     }
   }
@@ -363,6 +371,16 @@ function decode(body) {
       }
     })
   return form
+}
+
+function cloneFormData(formData) {
+  const cloned = new FormData()
+
+  formData.forEach(function(value, key) {
+    cloned.append(key, value)
+  })
+
+  return cloned
 }
 
 function parseHeaders(rawHeaders) {


### PR DESCRIPTION
The FormData object is cloned, since [the spec](https://fetch.spec.whatwg.org/#dom-body-formdata) says that it gets encoded to a stream and decoded again. This is consistent with the behaviour in browsers.

The stream is also consumed by doing this, so subsequent reads fail with a TypeError.

Fixes #460