### PR TITLE
Allow exclamation mark as valid header character

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -44,7 +44,7 @@ function normalizeName(name) {
   if (typeof name !== 'string') {
     name = String(name)
   }
-  if (/[^a-z0-9\-#$%&'*+.^_`|~]/i.test(name) || name === '') {
+  if (/[^a-z0-9\-#$%&'*+.^_`|~!]/i.test(name) || name === '') {
     throw new TypeError('Invalid character in header field name')
   }
   return name.toLowerCase()


### PR DESCRIPTION
In the [section 3.2.6 of the HTTP RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.6), it denotes the following about HTTP headers:

>  Most HTTP header field values are defined using common syntax
   components (token, quoted-string, and comment) separated by
   whitespace or specific delimiting characters.  Delimiters are chosen
   from the set of US-ASCII visual characters not allowed in a token
   (DQUOTE and "(),/:;<=>?@[\]{}").
>
>     token          = 1*tchar
>
>     tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
>                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
>                    / DIGIT / ALPHA
>                    ; any VCHAR, except delimiters

Note the `tchar` definition allows use of an exclamation mark, but the validator for `normalizeName` does not allow it.

This PR adds the exclamation mark to the list of allowed characters to header fields.

### Verification

Execute the following in the browser console:

```js
const headers = new Headers();
headers.append('test!', '123'); // Executes fine
headers.append('test:', '123'); // Throws a TypeError
```