### PR TITLE
Revert "Detect if DOMException exists via typeof instead of trying to call it and catching the exception which may get thrown"

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -462,8 +462,9 @@ Response.redirect = function(url, status) {
 }
 
 export var DOMException = global.DOMException
-
-if (typeof DOMException !== 'function') {
+try {
+  new DOMException()
+} catch (err) {
   DOMException = function(message, name) {
     this.message = message
     this.name = name


### PR DESCRIPTION
Reverts github/fetch#797

Some browser have `DOMException` but do not allow it to be constructed via `new`

Fixes https://github.com/github/fetch/issues/799