### PR TITLE
Make Response.arrayBuffer() always resolve with a `ArrayBuffer`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -274,7 +274,15 @@ function Body() {
 
     this.arrayBuffer = function() {
       if (this._bodyArrayBuffer) {
-        return consumed(this) || Promise.resolve(this._bodyArrayBuffer)
+        consumed(this)
+        if (ArrayBuffer.isView(this._bodyArrayBuffer)) {
+          return Promise.resolve(this._bodyArrayBuffer.buffer.slice(
+            this._bodyArrayBuffer.byteOffset,
+            this._bodyArrayBuffer.byteOffset + this._bodyArrayBuffer.byteLength
+          ))
+        } else {
+          return Promise.resolve(this._bodyArrayBuffer)
+        }
       } else {
         return this.blob().then(readBlobAsArrayBuffer)
       }

--- a/fetch.js
+++ b/fetch.js
@@ -276,10 +276,12 @@ function Body() {
       if (this._bodyArrayBuffer) {
         consumed(this)
         if (ArrayBuffer.isView(this._bodyArrayBuffer)) {
-          return Promise.resolve(this._bodyArrayBuffer.buffer.slice(
-            this._bodyArrayBuffer.byteOffset,
-            this._bodyArrayBuffer.byteOffset + this._bodyArrayBuffer.byteLength
-          ))
+          return Promise.resolve(
+            this._bodyArrayBuffer.buffer.slice(
+              this._bodyArrayBuffer.byteOffset,
+              this._bodyArrayBuffer.byteOffset + this._bodyArrayBuffer.byteLength
+            )
+          )
         } else {
           return Promise.resolve(this._bodyArrayBuffer)
         }


### PR DESCRIPTION
Fixes https://github.com/github/fetch/issues/801