### PR TITLE
blob.text is not a function #861

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -265,7 +265,8 @@ function Body() {
       }
 
       if (this._bodyBlob) {
-        return Promise.resolve(this._bodyBlob)
+        this.bodyUsed = false;
+        return Promise.resolve(this)
       } else if (this._bodyArrayBuffer) {
         return Promise.resolve(new Blob([this._bodyArrayBuffer]))
       } else if (this._bodyFormData) {


### PR DESCRIPTION
hope this help to chain blob response to support .text to get data as native fetch