### PR TITLE
to fix blob.text is not a function #861

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -265,7 +265,8 @@ function Body() {
       }
 
       if (this._bodyBlob) {
-        return Promise.resolve(this._bodyBlob)
+        this.bodyUsed = false
+        return Promise.resolve(this)
       } else if (this._bodyArrayBuffer) {
         return Promise.resolve(new Blob([this._bodyArrayBuffer]))
       } else if (this._bodyFormData) {


### PR DESCRIPTION
with this change, the proposal blob will send this to chain-like native fetch to get a text from the return blob data