### PR TITLE
add header name in case of error

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -50,7 +50,7 @@ function normalizeName(name) {
     name = String(name)
   }
   if (/[^a-z0-9\-#$%&'*+.^_`|~!]/i.test(name) || name === '') {
-    throw new TypeError('Invalid character in header field name: ' + name)
+    throw new TypeError('Invalid character in header field name: "' + name + '"')
   }
   return name.toLowerCase()
 }

--- a/fetch.js
+++ b/fetch.js
@@ -50,7 +50,7 @@ function normalizeName(name) {
     name = String(name)
   }
   if (/[^a-z0-9\-#$%&'*+.^_`|~!]/i.test(name) || name === '') {
-    throw new TypeError('Invalid character in header field name')
+    throw new TypeError('Invalid character in header field name: ' + name)
   }
   return name.toLowerCase()
 }


### PR DESCRIPTION
If an invalid name for a header is provided, the library throws an error. This is correct, but in certain scenarios it can be hard to understand which header name actually causes the error.

This PR appends the name of such error to the error message