### PR TITLE
add the URL to the failed request error messages

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -526,13 +526,13 @@ export function fetch(input, init) {
 
     xhr.onerror = function() {
       setTimeout(function() {
-        reject(new TypeError('Network request failed'))
+        reject(new TypeError('Network request failed: ' + request.url))
       }, 0)
     }
 
     xhr.ontimeout = function() {
       setTimeout(function() {
-        reject(new TypeError('Network request failed'))
+        reject(new TypeError('Network request failed: ' + request.url))
       }, 0)
     }
 


### PR DESCRIPTION
It would be useful to have the requested URL in error messages.
This PR adds it to the failed request errors.