### PR TITLE
Fix Response.statusText

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -450,7 +450,7 @@ export function Response(bodyInit, options) {
   this.type = 'default'
   this.status = options.status === undefined ? 200 : options.status
   this.ok = this.status >= 200 && this.status < 300
-  this.statusText = 'statusText' in options ? options.statusText : ''
+  this.statusText = options.statusText === undefined ? '' : '' + options.statusText
   this.headers = new Headers(options.headers)
   this.url = options.url || ''
   this._initBody(bodyInit)

--- a/test/test.js
+++ b/test/test.js
@@ -694,6 +694,16 @@ exercise.forEach(function(exerciseMode) {
         assert.equal(r.headers.get('content-type'), 'text/plain')
       })
 
+      test('construct with undefined statusText', function() {
+        var r = new Response('', {statusText: undefined})
+        assert.equal(r.statusText, '')
+      })
+
+      test('construct with null statusText', function() {
+        var r = new Response('', {statusText: null})
+        assert.equal(r.statusText, 'null')
+      })
+
       test('init object as first argument', function() {
         var r = new Response({
           status: 201,


### PR DESCRIPTION
Inside Response constructor, this line:
`this.statusText = 'statusText' in options ? options.statusText : ''` is incorrect and should be:
`this.statusText = options.statusText === undefined ? '' : '' + options.statusText`

### With Firefox 84, Chrome 88, WebKit 605.1.15 native Response gives:
 
- new Response('').statusText ==> ""
- new Response('', {statusText: undefined}).statusText ==> ""
- new Response('', {statusText: null}).statusText ==> "null" (yes a string)
- new Response('', {statusText: ''}).statusText ==> ""
- new Response('', {statusText: 'hello'}).statusText ==> "hello"
- new Response('', {statusText: 0}).statusText ==> '0'
- new Response('', {statusText: 1}).statusText ==> '1'

<details><summary>Screenshots</summary>
<p>

![chrome](https://user-images.githubusercontent.com/643434/106046471-972b3a00-60e2-11eb-9c2c-c8fce37d2777.png)

![firefox](https://user-images.githubusercontent.com/643434/106046496-9db9b180-60e2-11eb-97dc-4bd938c1ce77.png)

![webkit](https://user-images.githubusercontent.com/643434/106046506-a316fc00-60e2-11eb-87cd-2e7d698bcfdf.png)

</p>
</details>

### With whatwg-fetch 3.0.5 you get:

- new Response('').statusText ==> "" ==> OK
- new Response('', {statusText: undefined}).statusText ==> undefined ==> **KO (should be "")**
- new Response('', {statusText: null}).statusText ==> null ==> **KO (should be a string)**
- new Response('', {statusText: ''}).statusText ==> "" ==> OK
- new Response('', {statusText: 'hello'}).statusText ==> "hello" ==> OK
- new Response('', {statusText: 0}).statusText ==> 0 ==> **KO (should be a string)**
- new Response('', {statusText: 1}).statusText ==> 1 ==> **KO (should be a string)**
