### PR TITLE
Fix eslint and eslint-plugin-github dependency conflicts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "parserOptions": {
+    "ecmaVersion": 2015,
     "sourceType": "module"
   },
   "globals": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "devDependencies": {
     "abortcontroller-polyfill": "^1.1.9",
     "chai": "^4.1.2",
-    "eslint": "^4.19.1",
-    "eslint-plugin-github": "^1.6.0",
+    "eslint": "^7.20.0",
+    "eslint-plugin-github": "^4.1.1",
     "karma": "^3.0.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -104,7 +104,6 @@ if (!self.fetch.polyfill) {
 var slice = Array.prototype.slice
 
 function featureDependent(testOrSuite, condition) {
-  // eslint-disable-next-line no-invalid-this
   ;(condition ? testOrSuite : testOrSuite.skip).apply(this, slice.call(arguments, 2))
 }
 


### PR DESCRIPTION
Fix for this report:

```
# npm resolution error report

2021-02-17T16:13:57.668Z

Found: eslint@4.19.1
node_modules/eslint
  dev eslint@"^4.19.1" from the root project
  peer eslint@">=4.19.1" from eslint-plugin-eslint-comments@3.2.0
  node_modules/eslint-plugin-eslint-comments
    eslint-plugin-eslint-comments@">=3.0.1" from eslint-plugin-github@1.10.0
    node_modules/eslint-plugin-github
      dev eslint-plugin-github@"^1.6.0" from the root project
  peer eslint@"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0" from eslint-plugin-import@2.22.1
  node_modules/eslint-plugin-import
    eslint-plugin-import@">=2.11.0" from eslint-plugin-github@1.10.0
    node_modules/eslint-plugin-github
      dev eslint-plugin-github@"^1.6.0" from the root project
  peer eslint@">=4.19.0" from eslint-plugin-github@1.10.0
  node_modules/eslint-plugin-github
    dev eslint-plugin-github@"^1.6.0" from the root project

Could not resolve dependency:
peer eslint@"^5.0.0" from @typescript-eslint/parser@1.13.0
node_modules/eslint-plugin-github/node_modules/@typescript-eslint/parser
  @typescript-eslint/parser@"^1.3.0" from eslint-plugin-github@1.10.0
  node_modules/eslint-plugin-github
    dev eslint-plugin-github@"^1.6.0" from the root project
  peer @typescript-eslint/parser@"^1.9.0" from @typescript-eslint/eslint-plugin@1.13.0
  node_modules/eslint-plugin-github/node_modules/@typescript-eslint/eslint-plugin
    @typescript-eslint/eslint-plugin@"^1.3.0" from eslint-plugin-github@1.10.0
    node_modules/eslint-plugin-github
      dev eslint-plugin-github@"^1.6.0" from the root project

Fix the upstream dependency conflict, or retry
this command with --force, or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.
```