### PR TITLE
Fix MSIE compatibility

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -246,7 +246,7 @@ function Body() {
       this._bodyText = body = Object.prototype.toString.call(body)
     }
 
-    const contentType = this.headers.get('content-type')
+    var contentType = this.headers.get('content-type')
 
     if (!contentType) {
       if (typeof body === 'string') {

--- a/fetch.js
+++ b/fetch.js
@@ -256,7 +256,7 @@ function Body() {
       } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
         this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
       }
-    } else if (contentType.includes('json') && typeof this._bodyInit !== 'string') {
+    } else if (contentType.indexOf('json') >= 0 && typeof this._bodyInit !== 'string') {
       // Always pass a text representation of a non-stringified JSON body
       // to `XMLHttpRequest.send` to retain a compatible behavior with the browser.
       this._bodyInit = this._bodyText

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whatwg-fetch",
   "description": "A window.fetch polyfill.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "./dist/fetch.umd.js",
   "module": "./fetch.js",
   "repository": "github/fetch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whatwg-fetch",
   "description": "A window.fetch polyfill.",
-  "version": "3.6.1",
+  "version": "3.6.0",
   "main": "./dist/fetch.umd.js",
   "module": "./fetch.js",
   "repository": "github/fetch",


### PR DESCRIPTION
Version 3.6.0 (https://github.com/github/fetch/pull/881/files#diff-3fc6f1265a180d15035618e36ca1da88d092bacb4fc10a423938fa62e4f5f58fR259) broke MSIE compatibility.
`String.prototype.includes` is not available within any version of MSIE – [see compatibility table on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#browser_compatibility)