### PR TITLE
fix: ignore not throw on invalid response headers

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -437,7 +437,11 @@ function parseHeaders(rawHeaders) {
       var key = parts.shift().trim()
       if (key) {
         var value = parts.join(':').trim()
-        headers.append(key, value)
+        try {
+          headers.append(key, value)
+        } catch (error) {
+          console.warn('Response ' + error.message)
+        }
       }
     })
   return headers

--- a/test/server.js
+++ b/test/server.js
@@ -120,6 +120,14 @@ const routes = {
       'Content-Type': 'text/html; charset=utf-8'
     })
     res.end()
+  },
+  '/invalid-headers': function(res) {
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Invalid Header': 'valid value',
+      'Westworld-S01': "<3"
+    })
+    res.end()
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1281,6 +1281,12 @@ exercise.forEach(function(exerciseMode) {
             assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8')
           })
         })
+        test('parses invalid headers', function() {
+          return fetch('/invalid-headers').then(function(response) {
+            assert.equal(response.headers.get('Content-Type'), 'text/plain')
+            assert.equal(response.headers.get('Westworld-S01'), '<3')
+          })
+        })
       })
 
       // https://fetch.spec.whatwg.org/#methods


### PR DESCRIPTION
@JakeChampion I think the fix is fine, however I struggle with the test. It runs into the same problem that the response headers are validated. But I can't figure out which package supplies this code. None of the `node_modules` has a `_http_outgoing.js` that I could monkey-patch for this one response to not validate the response headers.

I also can't just test `parseHeaders()` since its private and not globally exported (rightfully so).

So do you have any idea how to test my fix properly?

Fixes #930