### PR TITLE
Get the proper global object depending on environment to check for existing fetch

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -605,9 +605,19 @@ export function fetch(input, init) {
 
 fetch.polyfill = true
 
-if (!global.fetch) {
-  global.fetch = fetch
-  global.Headers = Headers
-  global.Request = Request
-  global.Response = Response
+var getGlobal = function () {
+  if (typeof globalThis !== 'undefined') { return globalThis }
+  if (typeof self !== 'undefined') { return self }
+  if (typeof window !== 'undefined') { return window }
+  if (typeof global !== 'undefined') { return global }
+  throw new Error('unable to locate global object')
+}
+
+var globals = getGlobal()
+
+if (!globals.fetch) {
+  globals.fetch = fetch
+  globals.Headers = Headers
+  globals.Request = Request
+  globals.Response = Response
 }

--- a/fetch.js
+++ b/fetch.js
@@ -498,6 +498,14 @@ try {
 }
 
 export function fetch(input, init) {
+  if (XMLHttpRequest === 'undefined') {
+    if (globalThis !== 'undefined') {
+      if ('fetch' in globalThis) {
+        return globalThis.fetch(input, init)
+      }
+    }
+  }
+  
   return new Promise(function(resolve, reject) {
     var request = new Request(input, init)
 

--- a/fetch.js
+++ b/fetch.js
@@ -498,14 +498,6 @@ try {
 }
 
 export function fetch(input, init) {
-  if (XMLHttpRequest === 'undefined') {
-    if (globalThis !== 'undefined') {
-      if ('fetch' in globalThis) {
-        return globalThis.fetch(input, init)
-      }
-    }
-  }
-  
   return new Promise(function(resolve, reject) {
     var request = new Request(input, init)
 


### PR DESCRIPTION
This might be more of a conversation than a pull request, but I want to attempt to address an issue that's been noticed in a dependency, `cross-fetch`, that this might help solve.

As it stands, `XMLHttpRequest` doesn't exist in some runtimes, such as Deno or Cloudflare Workers. Tweaking this library might have a positive cascade of solving some issues, such as these:

https://github.com/supabase/supabase-js/issues/154
https://github.com/lquixada/cross-fetch/issues/78
https://github.com/supabase/supabase-js/issues/161