### PR TITLE
Compatible global equals to the false

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,7 +1,8 @@
 var global =
   (typeof globalThis !== 'undefined' && globalThis) ||
   (typeof self !== 'undefined' && self) ||
-  (typeof global !== 'undefined' && global)
+  (typeof global !== 'undefined' && global) ||
+  {}
 
 var support = {
   searchParams: 'URLSearchParams' in global,


### PR DESCRIPTION
In some special environments, such as webview in certain scenes.
`globalThis` `self` `global` Neither holds, var global will be equal to false.
The following code will throw an error.

```javascript
searchParams: 'URLSearchParams' in global,
iterable: 'Symbol' in global && 'iterator' in Symbol,

// 'URLSearchParams' in false
```

**TypeError: Cannot use 'in' operator to search for 'URLSearchParams' in false**