### PR TITLE
always set a signal on Request

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -370,7 +370,12 @@ export function Request(input, options) {
   }
   this.method = normalizeMethod(options.method || this.method || 'GET')
   this.mode = options.mode || this.mode || null
-  this.signal = options.signal || this.signal
+  this.signal = options.signal || this.signal || (function () {
+    if ('AbortController' in global) {
+      var ctrl = new AbortController();
+      return ctrl.signal;
+    }
+  }());
   this.referrer = null
 
   if ((this.method === 'GET' || this.method === 'HEAD') && body) {

--- a/test/test.js
+++ b/test/test.js
@@ -1147,7 +1147,20 @@ exercise.forEach(function(exerciseMode) {
       })
 
       featureDependent(suite, exerciseMode !== 'native' || support.aborting, 'aborting', function() {
-        test('initially aborted signal', function() {
+        test('Request init creates an AbortSignal without option', function() {
+          var request = new Request('/request')
+          assert.ok(request.signal);
+          assert.equal(request.signal.aborted, false);
+        })
+
+        test('Request init passes AbortSignal from option', function () {
+          var controller = new AbortController()
+          var request = new Request('/request', {signal: controller.signal})
+          assert.ok(request.signal);
+          assert.deepEqual(controller.signal, request.signal);
+        })
+
+        test('initially aborted signal', function () {
           var controller = new AbortController()
           controller.abort()
 


### PR DESCRIPTION
https://fetch.spec.whatwg.org/#request-class

new Request(input, init) constructor step : 28

> Set this’s signal to a new AbortSignal object with this’s relevant Realm.

latest Chrome :

```js
new Request('').signal
// AbortSignal {aborted: false, onabort: null}
```

Also checked Safari/Firefox and this is implemented in all of them.

-------

I wasn't sure how to run the test suite.
I had een error that seemed unrelated to the actual feature tests :

```
25 07 2021 09:11:12.524:INFO [framework.detect-browsers]: The following browsers will be used: [ 'ChromeHeadlessNoSandbox',
  'ChromeCanaryHeadlessNoSandbox',
  'FirefoxHeadless',
  'Safari',
  'SafariTechPreview' ]
25 07 2021 09:11:12.605:INFO [karma-server]: Karma v3.1.4 server started at http://0.0.0.0:9877/
25 07 2021 09:11:12.605:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox, ChromeCanaryHeadlessNoSandbox, FirefoxHeadless, Safari, SafariTechPreview with concurrency unlimited
25 07 2021 09:11:12.610:ERROR [launcher]: Cannot load browser "ChromeCanaryHeadlessNoSandbox": it is not registered! Perhaps you are missing some plugin?
25 07 2021 09:11:12.611:ERROR [karma-server]: Error: Found 1 load error
    at Server.webServer.listen (./fetch/node_modules/karma/lib/server.js:182:27)
    at Object.onceWrapper (events.js:286:20)
    at Server.emit (events.js:203:15)
    at emitListeningNT (net.js:1314:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
25 07 2021 09:11:12.612:INFO [launcher]: Starting browser ChromeHeadless
25 07 2021 09:11:12.619:INFO [launcher]: Starting browser FirefoxHeadless
25 07 2021 09:11:12.636:INFO [launcher]: Starting browser Safari
25 07 2021 09:11:12.640:INFO [launcher]: Starting browser SafariTechPreview
```