### PR TITLE
Restrict eslint-plugin-github's version to compatible ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "abortcontroller-polyfill": "^1.1.9",
     "chai": "^4.1.2",
     "eslint": "^7.20.0",
-    "eslint-plugin-github": "^4.1.1",
+    "eslint-plugin-github": "4.1.x",
     "karma": "^3.0.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
Some changes on `eslint-plugin-github` are causing CI to fail in unintended ways, so I am trying to fix that.