### PR TITLE
Remove error that causes ie11 to be unresponsive

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -50,9 +50,6 @@ function normalizeName(name) {
   if (typeof name !== 'string') {
     name = String(name)
   }
-  if (/[^a-z0-9\-#$%&'*+.^_`|~!]/i.test(name) || name === '') {
-    throw new TypeError('Invalid character in header field name: "' + name + '"')
-  }
   return name.toLowerCase()
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "whatwg-fetch",
+  "name": "fetch-ie11",
   "description": "A window.fetch polyfill.",
   "version": "3.6.2",
   "main": "./dist/fetch.umd.js",

--- a/test/test.js
+++ b/test/test.js
@@ -255,21 +255,6 @@ exercise.forEach(function(exerciseMode) {
         assert.equal(headers.get('Content-Type'), '1')
         assert.equal(headers.get('X-CSRF-Token'), 'undefined')
       })
-      test('throws TypeError on invalid character in field name', function() {
-        assert.throws(function() {
-          new Headers({'[Accept]': 'application/json'})
-        }, TypeError)
-        assert.throws(function() {
-          new Headers({'Accept:': 'application/json'})
-        }, TypeError)
-        assert.throws(function() {
-          var headers = new Headers()
-          headers.set({field: 'value'}, 'application/json')
-        }, TypeError)
-        assert.throws(function() {
-          new Headers({'': 'application/json'})
-        }, TypeError)
-      })
       featureDependent(test, !brokenFF, 'is iterable with forEach', function() {
         var headers = new Headers()
         headers.append('Accept', 'application/json')


### PR DESCRIPTION
The headers of requests to Zendesk and Sentry contain colons, e.g.

:authority
:scheme
:method
:path

Those headers cause this error to be thrown. This error is thrown continuously because Sentry's JavaScript continues to send the error to Sentry. Every fetch request to Sentry causes another error. When the requests are in an infinite loop, IE 11 becomes unresponsive.