### PR TITLE
Update caniuse link to use HTTPS and new pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ As an alternative to using npm, you can obtain `fetch.umd.js` from the
 [Releases][] section. The UMD distribution is compatible with AMD and CommonJS
 module loaders, as well as loading directly into a page via `<script>` tag.
 
-You will also need a Promise polyfill for [older browsers](http://caniuse.com/#feat=promises).
+You will also need a Promise polyfill for [older browsers](https://caniuse.com/promises).
 We recommend [taylorhakes/promise-polyfill](https://github.com/taylorhakes/promise-polyfill)
 for its small size and Promises/A+ compatibility.
 


### PR DESCRIPTION
Checked the link, skipping the redirect HTTP => HTTPS and to the new pattern this way 0:-)