### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -430,7 +430,7 @@ function parseHeaders(rawHeaders) {
   preProcessedHeaders
     .split('\r')
     .map(function(header) {
-      return header.indexOf('\n') === 0 ? header.substr(1, header.length) : header
+      return header.indexOf('\n') === 0 ? header.slice(1) : header
     })
     .forEach(function(line) {
       var parts = line.split(':')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.