### PR TITLE
Add some missed methods which should be normalized as uppercase

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -329,7 +329,7 @@ function Body() {
 }
 
 // HTTP methods whose capitalization should be normalized
-var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+var methods = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE']
 
 function normalizeMethod(method) {
   var upcased = method.toUpperCase()


### PR DESCRIPTION
Recently I found that the polyfill for `fetch()` has not normalized the `patch` method as uppercase, and it seems like a bug like native implementation. Should we add some request methods to solve this problem?

REF: https://github.com/nodejs/help/issues/2184