### PR TITLE
fix: catch and reject with error if new Response throws inside resolve

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -551,8 +551,10 @@ export function fetch(input, init) {
       }
       options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
       var body = 'response' in xhr ? xhr.response : xhr.responseText
-      setTimeout(function() {
-        resolve(new Response(body, options))
+      setTimeout(function () {
+        try {
+          resolve(new Response(body, options))
+        } catch (e) { reject(e) }
       }, 0)
     }
 


### PR DESCRIPTION
If Response() throws when fetch() is trying to resolve it'll throw an error that can't be handled.

This change would catch the error when trying to resolve and instead reject the fetch promise with the error so it can be handled by a catch higher up.

I ran into this issue in a react-native project when a server unpredictably returned a 600 status code, ultimately causing react-native to panic/crash and I was unable to handle the thrown RangeError in any way.