### PR TITLE
For request failures and timeouts, include the URLs in the errors

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -558,13 +558,13 @@ export function fetch(input, init) {
 
     xhr.onerror = function() {
       setTimeout(function() {
-        reject(new TypeError('Network request failed'))
+        reject(new TypeError('Network request ('+request.method+' '+request.url+') failed'))
       }, 0)
     }
 
     xhr.ontimeout = function() {
       setTimeout(function() {
-        reject(new TypeError('Network request timed out'))
+        reject(new TypeError('Network request ('+request.method+' '+request.url+') timed out'))
       }, 0)
     }
 


### PR DESCRIPTION
When working with complex Jest tests which mount large component trees, it can be difficult to nail down which request is causing test failures with the current message. Echo the specific method and URL into the Error, so that debugging is easier.