### PR TITLE
Use AbortSignal.throwIfAborted() to copy abort reason

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -226,8 +226,8 @@ function Body() {
     /*
       fetch-mock wraps the Response object in an ES6 Proxy to
       provide useful test harness features such as flush. However, on
-      ES5 browsers without fetch or Proxy support pollyfills must be used;
-      the proxy-pollyfill is unable to proxy an attribute unless it exists
+      ES5 browsers without fetch or Proxy support polyfills must be used;
+      the proxy-polyfill is unable to proxy an attribute unless it exists
       on the object before the Proxy is created. This change ensures
       Response.bodyUsed exists on the instance, while maintaining the
       semantic of setting Request.bodyUsed in the constructor before

--- a/fetch.js
+++ b/fetch.js
@@ -528,6 +528,9 @@ export function fetch(input, init) {
     var request = new Request(input, init)
 
     if (request.signal && request.signal.aborted) {
+      if (request.signal.throwIfAborted) {
+        request.signal.throwIfAborted()
+      }
       return reject(new DOMException('Aborted', 'AbortError'))
     }
 
@@ -570,7 +573,15 @@ export function fetch(input, init) {
 
     xhr.onabort = function() {
       setTimeout(function() {
-        reject(new DOMException('Aborted', 'AbortError'))
+        if (request.signal && request.signal.aborted && request.signal.throwIfAborted) {
+          try {
+            request.signal.throwIfAborted()
+          } catch (e) {
+            reject(e)
+          }
+        } else {
+          reject(new DOMException('Aborted', 'AbortError'))
+        }
       }, 0)
     }
 


### PR DESCRIPTION
Fixes #1477.