### PR TITLE
Make `Headers` instantiable from native `Headers`

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -21,7 +21,8 @@ var support = {
       }
     })(),
   formData: 'FormData' in g,
-  arrayBuffer: 'ArrayBuffer' in g
+  arrayBuffer: 'ArrayBuffer' in g,
+  headers: 'Headers' in g && g.Headers,
 }
 
 function isDataView(obj) {
@@ -86,7 +87,7 @@ function iteratorFor(items) {
 export function Headers(headers) {
   this.map = {}
 
-  if (headers instanceof Headers) {
+  if (headers instanceof Headers || (support.headers && headers instanceof support.headers)) {
     headers.forEach(function(value, name) {
       this.append(name, value)
     }, this)

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,8 @@ var support = {
   formData: 'FormData' in self,
   arrayBuffer: 'ArrayBuffer' in self,
   aborting: 'signal' in new Request(''),
-  permanentRedirect: !/Trident/.test(navigator.userAgent)
+  permanentRedirect: !/Trident/.test(navigator.userAgent),
+  headers: 'Headers' in self && self.Headers,
 }
 
 function readBlobAsText(blob) {
@@ -213,6 +214,16 @@ exercise.forEach(function(exerciseMode) {
             ['Content-Type', 'a', 'b'],
           ])
         }, TypeError)
+      })
+      featureDependent(test, support.headers, 'constructor copies headers from native Headers', function() {
+        var original = new support.headers()
+        original.append('Accept', 'application/json')
+        original.append('Accept', 'text/plain')
+        original.append('Content-Type', 'text/html')
+
+        var headers = new Headers(original)
+        assert.equal(headers.get('Accept'), 'application/json, text/plain')
+        assert.equal(headers.get('Content-type'), 'text/html')
       })
       test('headers are case insensitive', function() {
         var headers = new Headers({Accept: 'application/json'})


### PR DESCRIPTION
Given, that I have two `fetch` middlewares:

```js
// FirstMiddleware.js
export function firstMiddleware(req, next) {
  const headers = new Headers(req.headers); // native Headers type
  headers.set('X-Foo', 'bar');
  return next({ ...req, headers });
}

// SecondMiddleware.js
import { Headers } from 'node-fetch';

export function secondMiddleware(req, next) {
  const headers = new Headers(req.headers); // a polyfill type
  headers.set('X-Bar', 'bar');
  return next({ ...req, headers });
}
```

In `SecondMiddleware`, the pre-added headers are no longer kept, as the polyfill can not handle the native type, if it is available for any reason.  
This PR fixes this issue.